### PR TITLE
MVP: Add AI Issue→PR workflow (Groq) with generator scripts and docs

### DIFF
--- a/.github/workflows/ai-issue-to-pr.yml
+++ b/.github/workflows/ai-issue-to-pr.yml
@@ -1,0 +1,61 @@
+name: AI Issue to PR
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-pr:
+    if: contains(github.event.issue.labels.*.name, 'ai-task')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate AI change
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GROQ_MODEL: ${{ vars.GROQ_MODEL }}
+          GROQ_API_URL: ${{ vars.GROQ_API_URL }}
+        run: node scripts/generate_issue_change.mjs
+
+      - name: Read generated summary
+        id: summary
+        shell: bash
+        run: |
+          {
+            echo "value<<EOF"
+            cat .ai-summary.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ai/issue-${{ github.event.issue.number }}
+          base: ${{ github.event.repository.default_branch }}
+          commit-message: chore(ai): generate draft for issue #${{ github.event.issue.number }}
+          title: "[AI] Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
+          body: |
+            ## AI Generated Change
+
+            ${{ steps.summary.outputs.value }}
+
+            Closes #${{ github.event.issue.number }}
+          add-paths: |
+            ai-generated/issue-${{ github.event.issue.number }}.md
+            .ai-summary.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS Guidelines
+
+This file provides working conventions for AI agents contributing to this repository.
+
+## Scope
+
+These instructions apply to the entire repository.
+
+## Objectives
+
+- Keep changes MVP-focused and small.
+- Prefer safe, deterministic behavior over broad automation.
+- Fail fast on external API errors; never open PRs on failed generation.
+
+## Engineering Rules
+
+- Keep workflow YAML files dumb: orchestration only, business logic in Node.js scripts/modules.
+- Use Node.js for helper scripts and automation utilities.
+- Avoid multi-file refactors unless explicitly requested.
+- Keep generated output constrained to predictable locations.
+- Use repository secrets/variables for all external credentials/configuration.
+
+## Workflow Rules
+
+- Issue automation is opt-in by label (`ai-task`).
+- Branch naming must follow `ai/issue-<number>`.
+- PR descriptions should include `Closes #<issue_number>`.
+- Do not implement auto-merge in MVP.
+
+## Documentation Rules
+
+- Update `docs/ai-issue-to-pr.md` when workflow inputs or setup requirements change.
+- Record major architectural decisions in `docs/adr/` as numbered ADR files.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # autonomous-dev-loop
+
 A fully autonomous GitHub-native dev loop: Issue → AI coder → PR → AI reviewer → iterative loop → human merge gate.
+
+## MVP Automation Implemented
+
+The MVP issue-to-PR automation is now implemented (Groq-backed).
+
+- Workflow: `.github/workflows/ai-issue-to-pr.yml` (kept minimal/orchestration-only)
+- Generator script: `scripts/generate_issue_change.mjs`
+- Generator modules: `scripts/lib/*.mjs`
+- Setup and testing guide: `docs/ai-issue-to-pr.md`
+- MVP definition: `docs/mvp.md`
+
+See `docs/ai-issue-to-pr.md` for required Groq secret + optional variables, label configuration, end-to-end test steps, and risk/mitigation notes.
+
+
+## Architecture Decisions
+
+- ADR index: `docs/adr/README.md`

--- a/docs/adr/0001-trigger-policy-and-label-gate.md
+++ b/docs/adr/0001-trigger-policy-and-label-gate.md
@@ -1,0 +1,18 @@
+# ADR-0001: Trigger policy and label gate
+
+- **Date:** 2026-04-14
+- **Status:** Accepted
+
+## Context
+
+The MVP must run automatically from GitHub issues while avoiding accidental executions.
+
+## Decision
+
+Use a GitHub Actions workflow triggered on `issues.opened`, and run the job only when the issue includes label `ai-task`.
+
+## Consequences
+
+- ✅ Reduces unwanted runs and noisy PR generation.
+- ✅ Keeps activation explicit and predictable.
+- ⚠️ If the label is added after issue creation, this workflow run will not trigger (MVP limitation).

--- a/docs/adr/0002-ai-provider-groq.md
+++ b/docs/adr/0002-ai-provider-groq.md
@@ -1,0 +1,21 @@
+# ADR-0002: AI provider choice (Groq)
+
+- **Date:** 2026-04-14
+- **Status:** Accepted
+
+## Context
+
+The automation needs an external AI provider with secret-based authentication and a simple API contract.
+
+## Decision
+
+Use Groq Chat Completions API with:
+- Required secret: `GROQ_API_KEY`
+- Optional variables: `GROQ_MODEL`, `GROQ_API_URL`
+- Deterministic generation settings in MVP (temperature `0`).
+
+## Consequences
+
+- ✅ Matches repository setup where Groq key is configured in Actions secrets.
+- ✅ Easy provider configuration without hardcoding credentials.
+- ⚠️ Workflow availability depends on Groq API uptime/limits.

--- a/docs/adr/0003-safe-output-scope.md
+++ b/docs/adr/0003-safe-output-scope.md
@@ -1,0 +1,21 @@
+# ADR-0003: Safe output scope (single generated file)
+
+- **Date:** 2026-04-14
+- **Status:** Accepted
+
+## Context
+
+MVP requires low-risk automated code changes and clear failure behavior.
+
+## Decision
+
+Constrain generation to a single predictable file path:
+- `ai-generated/issue-<number>.md`
+
+The workflow fails fast and does not open a PR if AI call/validation/patch steps fail.
+
+## Consequences
+
+- ✅ Minimizes blast radius of generated changes.
+- ✅ Keeps review surface small and easy to audit.
+- ⚠️ Limits usefulness for tasks requiring multi-file edits (out of scope for MVP).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,9 @@
+# ADR Index
+
+Architecture Decision Records (ADR) for the MVP Issue → AI → PR automation.
+
+## Records
+
+- [ADR-0001: Trigger policy and label gate](./0001-trigger-policy-and-label-gate.md)
+- [ADR-0002: AI provider choice (Groq)](./0002-ai-provider-groq.md)
+- [ADR-0003: Safe output scope (single generated file)](./0003-safe-output-scope.md)

--- a/docs/ai-issue-to-pr.md
+++ b/docs/ai-issue-to-pr.md
@@ -1,0 +1,76 @@
+# AI Issue-to-PR MVP Setup (Groq)
+
+This repository includes an MVP workflow that converts newly created, labeled issues into AI-generated draft pull requests using Groq.
+
+## Workflow Overview
+
+File: `.github/workflows/ai-issue-to-pr.yml`
+
+Workflow design note: YAML stays intentionally minimal (orchestration only). Most logic lives in Node modules for future unit testing.
+
+Node implementation:
+- Entrypoint: `scripts/generate_issue_change.mjs`
+- Modules: `scripts/lib/config.mjs`, `scripts/lib/groq_client.mjs`, `scripts/lib/output_writer.mjs`
+
+On issue creation, the workflow:
+1. Runs only when the issue includes the `ai-task` label.
+2. Builds a deterministic prompt using issue number, title, and body.
+3. Calls the Groq API using repository secrets.
+4. Writes a minimal generated file at `ai-generated/issue-<number>.md`.
+5. Creates a branch named `ai/issue-<number>`.
+6. Uses `peter-evans/create-pull-request` to commit generated content on `ai/issue-<number>`.
+7. Opens a PR to the repository default branch with `Closes #<issue_number>`.
+
+If generation fails or no patch is produced, the workflow exits before PR creation.
+
+## Required Secrets
+
+Configure these in **Settings → Secrets and variables → Actions**:
+
+- **Secret**: `GROQ_API_KEY` (required) — API key for Groq.
+- **Variables** (optional):
+  - `GROQ_MODEL` — model name (defaults to `llama-3.1-8b-instant` if unset).
+  - `GROQ_API_URL` — endpoint URL (defaults to `https://api.groq.com/openai/v1/chat/completions` if unset).
+
+## Required Label
+
+Create and use this issue label:
+
+- `ai-task`
+
+Only issues created with this label trigger the automation job.
+
+## End-to-End Test
+
+1. Ensure secrets above are configured.
+2. Ensure the `ai-task` label exists.
+3. Create a new GitHub issue with:
+   - label: `ai-task`
+   - a short title and body describing a small docs/code task.
+4. Open **Actions** and confirm run `AI Issue to PR` starts.
+5. Verify logs for:
+   - prompt construction
+   - Groq API call success
+   - branch creation (`ai/issue-<number>`)
+   - PR creation
+6. Confirm PR details:
+   - title references the issue number/title
+   - body includes generated summary and `Closes #<number>`
+   - changed file limited to `ai-generated/issue-<number>.md`
+
+## Limitations (MVP)
+
+- Only handles issue `opened` events.
+- Only runs when label is present at issue creation time.
+- Applies a single small generated markdown file (safe scope).
+- Does not perform auto-merge.
+- Does not attempt multi-file or complex refactors.
+
+## Risk and Mitigation Note
+
+- **Risk:** AI output may be low quality or off-target.
+  - **Mitigation:** deterministic prompt template, temperature `0`, and small-scope generated file.
+- **Risk:** accidental broad modifications.
+  - **Mitigation:** generated patch is constrained to one predictable path (`ai-generated/issue-<number>.md`).
+- **Risk:** workflow secrets misconfiguration.
+  - **Mitigation:** explicit secret checks and fail-fast logging before commit/PR steps.

--- a/scripts/generate_issue_change.mjs
+++ b/scripts/generate_issue_change.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import { buildDeterministicPrompt, loadConfigFromEnv } from './lib/config.mjs';
+import { callGroq } from './lib/groq_client.mjs';
+import { validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
+
+async function main() {
+  const config = loadConfigFromEnv();
+  const prompt = buildDeterministicPrompt(config);
+
+  console.log('[INFO] Calling Groq model with deterministic prompt template...');
+  const aiOutput = await callGroq({
+    prompt,
+    apiKey: config.apiKey,
+    model: config.model,
+    apiUrl: config.apiUrl,
+  });
+
+  const { summary, contentMarkdown } = validateAiOutput(aiOutput);
+  const outputPath = await writeGeneratedFiles({
+    issueNumber: config.issueNumber,
+    issueTitle: config.issueTitle,
+    summary,
+    contentMarkdown,
+  });
+
+  console.log(`[INFO] Wrote generated change: ${outputPath}`);
+  console.log('[INFO] Wrote PR summary helper: .ai-summary.txt');
+}
+
+main().catch((error) => {
+  console.error(`[ERROR] ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -1,0 +1,48 @@
+export function requireEnv(name) {
+  const value = (process.env[name] || '').trim();
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export function loadConfigFromEnv() {
+  const issueNumber = requireEnv('ISSUE_NUMBER');
+  const issueTitle = requireEnv('ISSUE_TITLE');
+  const issueBody = (process.env.ISSUE_BODY || '').trim() || '(no body provided)';
+
+  const apiKey = requireEnv('GROQ_API_KEY');
+  const model = (process.env.GROQ_MODEL || 'llama-3.1-8b-instant').trim();
+  const apiUrl = (process.env.GROQ_API_URL || 'https://api.groq.com/openai/v1/chat/completions').trim();
+
+  return {
+    issueNumber,
+    issueTitle,
+    issueBody,
+    apiKey,
+    model,
+    apiUrl,
+  };
+}
+
+export function buildDeterministicPrompt({ issueNumber, issueTitle, issueBody }) {
+  return [
+    'Create a minimal, safe markdown draft for a pull request based on a GitHub issue.',
+    '',
+    'Deterministic issue data:',
+    `- issue_number: ${issueNumber}`,
+    `- issue_title: ${issueTitle}`,
+    `- issue_body: ${issueBody}`,
+    '',
+    'Requirements:',
+    '1) Keep scope small and non-destructive.',
+    '2) Produce markdown content only suitable for a single file update.',
+    '3) Be concise and actionable.',
+    '',
+    'Output JSON only:',
+    '{',
+    '  "summary": "One sentence summary of the generated change",',
+    '  "content_markdown": "Markdown body for the generated file"',
+    '}',
+  ].join('\n');
+}

--- a/scripts/lib/groq_client.mjs
+++ b/scripts/lib/groq_client.mjs
@@ -1,0 +1,54 @@
+export async function callGroq({ prompt, apiKey, model, apiUrl }) {
+  const payload = {
+    model,
+    temperature: 0,
+    response_format: { type: 'json_object' },
+    messages: [
+      {
+        role: 'system',
+        content:
+          'You generate small, safe repository changes. Return strict JSON with keys summary and content_markdown.',
+      },
+      { role: 'user', content: prompt },
+    ],
+  };
+
+  const response = await fetch(apiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const rawText = await response.text();
+  if (!response.ok) {
+    throw new Error(`Groq API HTTP error ${response.status}: ${rawText}`);
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(rawText);
+  } catch {
+    throw new Error('Groq API returned non-JSON response');
+  }
+
+  const content = raw?.choices?.[0]?.message?.content;
+  if (!content || typeof content !== 'string') {
+    throw new Error('Unexpected Groq API response format');
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error('AI response was not valid JSON');
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('AI response JSON must be an object');
+  }
+
+  return parsed;
+}

--- a/scripts/lib/output_writer.mjs
+++ b/scripts/lib/output_writer.mjs
@@ -1,0 +1,29 @@
+import fs from 'node:fs/promises';
+
+export function validateAiOutput(aiOutput) {
+  const summary = String(aiOutput.summary || '').trim();
+  const contentMarkdown = String(aiOutput.content_markdown || '').trim();
+
+  if (!summary) {
+    throw new Error('AI response missing non-empty summary');
+  }
+  if (!contentMarkdown) {
+    throw new Error('AI response missing non-empty content_markdown');
+  }
+  if (contentMarkdown.length > 8000) {
+    throw new Error('AI response content_markdown too large (>8000 chars)');
+  }
+
+  return { summary, contentMarkdown };
+}
+
+export async function writeGeneratedFiles({ issueNumber, issueTitle, summary, contentMarkdown }) {
+  const outputPath = `ai-generated/issue-${issueNumber}.md`;
+  const fileContent = `# AI Draft for Issue #${issueNumber}\n\n**Title:** ${issueTitle}\n\n## Generated Proposal\n\n${contentMarkdown}\n`;
+
+  await fs.mkdir('ai-generated', { recursive: true });
+  await fs.writeFile(outputPath, fileContent, 'utf8');
+  await fs.writeFile('.ai-summary.txt', `${summary}\n`, 'utf8');
+
+  return outputPath;
+}


### PR DESCRIPTION
### Motivation

- Add an opt-in, minimal-risk automation to convert labeled GitHub issues into AI-generated draft PRs using Groq. 
- Constrain generated output to a single predictable file and require repository secrets/variables for external API access to reduce blast radius. 
- Provide operational and architecture guidance for agents and future work via `AGENTS.md` and ADRs. 

### Description

- Add a GitHub Actions workflow `.github/workflows/ai-issue-to-pr.yml` that triggers on `issues.opened`, gates execution on the `ai-task` label, creates branch `ai/issue-<number>`, and opens a PR using `peter-evans/create-pull-request`. 
- Implement the Node entrypoint `scripts/generate_issue_change.mjs` and helper modules `scripts/lib/config.mjs`, `scripts/lib/groq_client.mjs`, and `scripts/lib/output_writer.mjs` to build a deterministic prompt, call the Groq API, parse strict JSON output, validate content, and write `ai-generated/issue-<number>.md` plus `.ai-summary.txt`. 
- Add documentation and decision records: `docs/ai-issue-to-pr.md`, `docs/adr/0001-*`, `0002-*`, `0003-*`, and ADR index, and update `README.md` to list the MVP automation. 
- Enforce safety measures including deterministic model settings (`temperature: 0`), strict JSON parsing, size limits on `content_markdown`, and fail-fast behavior to avoid creating PRs on error. 

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de511059f08325999c6ddd97b70162)