### PR TITLE
fix: resolve YAML syntax error in ai-issue-to-pr workflow

### DIFF
--- a/.github/workflows/ai-issue-to-pr.yml
+++ b/.github/workflows/ai-issue-to-pr.yml
@@ -48,7 +48,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ai/issue-${{ github.event.issue.number }}
           base: ${{ github.event.repository.default_branch }}
-          commit-message: chore(ai): generate draft for issue #${{ github.event.issue.number }}
+          commit-message: "chore(ai): generate draft for issue #${{ github.event.issue.number }}"
           title: "[AI] Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
           body: |
             ## AI Generated Change


### PR DESCRIPTION
### Motivation
- Fix a YAML parse failure in `.github/workflows/ai-issue-to-pr.yml` where the unquoted `commit-message` value contained a colon and caused an `Invalid workflow file` error.

### Description
- Quote the `commit-message` scalar in `.github/workflows/ai-issue-to-pr.yml` to `"chore(ai): generate draft for issue #${{ github.event.issue.number }}"` so the colon is not interpreted as YAML syntax, which prevents the workflow parse error; Closes #<issue_number>.

### Testing
- Parsed the workflow with Ruby using `YAML.load_file('.github/workflows/ai-issue-to-pr.yml')` which succeeded (`YAML OK`).
- Attempted `python` with `yaml.safe_load` failed because the `PyYAML` module is not installed in the environment (test failed due to missing dependency).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de661036748325bc922fd380c09c46)