### PR TITLE
Trigger AI Issue-to-PR on `ai-task` label and remove label after run

### DIFF
--- a/.github/workflows/ai-issue-to-pr.yml
+++ b/.github/workflows/ai-issue-to-pr.yml
@@ -2,15 +2,16 @@ name: AI Issue to PR
 
 on:
   issues:
-    types: [opened]
+    types: [labeled]
 
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   generate-pr:
-    if: contains(github.event.issue.labels.*.name, 'ai-task')
+    if: github.event.label.name == 'ai-task'
     runs-on: ubuntu-latest
 
     steps:
@@ -48,7 +49,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: ai/issue-${{ github.event.issue.number }}
           base: ${{ github.event.repository.default_branch }}
-          commit-message: chore(ai): generate draft for issue #${{ github.event.issue.number }}
+          commit-message: "chore(ai): generate draft for issue #${{ github.event.issue.number }}"
           title: "[AI] Issue #${{ github.event.issue.number }}: ${{ github.event.issue.title }}"
           body: |
             ## AI Generated Change
@@ -59,3 +60,24 @@ jobs:
           add-paths: |
             ai-generated/issue-${{ github.event.issue.number }}.md
             .ai-summary.txt
+
+      - name: Remove ai-task label
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            const hasAiTaskLabel = labels.some((label) => label.name === 'ai-task');
+            if (hasAiTaskLabel) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'ai-task'
+              });
+            }

--- a/docs/ai-issue-to-pr.md
+++ b/docs/ai-issue-to-pr.md
@@ -1,6 +1,6 @@
 # AI Issue-to-PR MVP Setup (Groq)
 
-This repository includes an MVP workflow that converts newly created, labeled issues into AI-generated draft pull requests using Groq.
+This repository includes an MVP workflow that converts issues labeled with `ai-task` into AI-generated draft pull requests using Groq.
 
 ## Workflow Overview
 
@@ -12,7 +12,7 @@ Node implementation:
 - Entrypoint: `scripts/generate_issue_change.mjs`
 - Modules: `scripts/lib/config.mjs`, `scripts/lib/groq_client.mjs`, `scripts/lib/output_writer.mjs`
 
-On issue creation, the workflow:
+When the `ai-task` label is added to an issue, the workflow:
 1. Runs only when the issue includes the `ai-task` label.
 2. Builds a deterministic prompt using issue number, title, and body.
 3. Calls the Groq API using repository secrets.
@@ -20,6 +20,7 @@ On issue creation, the workflow:
 5. Creates a branch named `ai/issue-<number>`.
 6. Uses `peter-evans/create-pull-request` to commit generated content on `ai/issue-<number>`.
 7. Opens a PR to the repository default branch with `Closes #<issue_number>`.
+8. Removes the `ai-task` label from the issue once the workflow run completes.
 
 If generation fails or no patch is produced, the workflow exits before PR creation.
 
@@ -38,30 +39,30 @@ Create and use this issue label:
 
 - `ai-task`
 
-Only issues created with this label trigger the automation job.
+Only issues where this label is actively applied trigger the automation job.
 
 ## End-to-End Test
 
 1. Ensure secrets above are configured.
 2. Ensure the `ai-task` label exists.
-3. Create a new GitHub issue with:
-   - label: `ai-task`
-   - a short title and body describing a small docs/code task.
-4. Open **Actions** and confirm run `AI Issue to PR` starts.
-5. Verify logs for:
+3. Create a new GitHub issue with a short title/body describing a small docs/code task.
+4. Add label `ai-task` to that issue.
+5. Open **Actions** and confirm run `AI Issue to PR` starts from the labeling event.
+6. Verify logs for:
    - prompt construction
    - Groq API call success
    - branch creation (`ai/issue-<number>`)
    - PR creation
-6. Confirm PR details:
+7. Confirm PR details:
    - title references the issue number/title
    - body includes generated summary and `Closes #<number>`
    - changed file limited to `ai-generated/issue-<number>.md`
+8. Confirm the issue label `ai-task` has been removed after the run completes.
 
 ## Limitations (MVP)
 
-- Only handles issue `opened` events.
-- Only runs when label is present at issue creation time.
+- Triggers on issue label application events.
+- Only runs when the applied label name is exactly `ai-task`.
 - Applies a single small generated markdown file (safe scope).
 - Does not perform auto-merge.
 - Does not attempt multi-file or complex refactors.


### PR DESCRIPTION
### Motivation

- Make the AI Issue-to-PR workflow trigger when the `ai-task` label is applied to an existing issue rather than only on issue creation.
- Ensure the automation cleans up by removing the `ai-task` label after the workflow completes to avoid re-triggering or clutter.

### Description

- Changed workflow trigger from `issues: types: [opened]` to `issues: types: [labeled]` and updated the conditional to `if: github.event.label.name == 'ai-task'` so the job runs on label application.
- Added `issues: write` permission to allow the workflow to remove labels on issues.
- Added a `Remove ai-task label` step using `actions/github-script@v7` that paginates labels on the issue and removes the `ai-task` label if present, running with `if: always()` to ensure cleanup.
- Updated docs in `docs/ai-issue-to-pr.md` to reflect the new trigger behavior and the new post-run label removal step, and clarified end-to-end test steps to add the label after creating an issue.

### Testing

- No automated unit or integration tests were added for these changes.
- The change is limited to workflow YAML and documentation edits and thus requires a labeled issue run in GitHub Actions to exercise end-to-end behavior; no automated runs were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de661036748325bc922fd380c09c46)