### PR TITLE
fix(workflow): allow AI workflow to use dedicated PR token when GITHUB_TOKEN PR creation is blocked

### DIFF
--- a/.github/workflows/ai-issue-to-pr.yml
+++ b/.github/workflows/ai-issue-to-pr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AI_PR_TOKEN || secrets.GITHUB_TOKEN }}
           branch: ai/issue-${{ github.event.issue.number }}
           base: ${{ github.event.repository.default_branch }}
           commit-message: "chore(ai): generate draft for issue #${{ github.event.issue.number }}"
@@ -65,7 +65,7 @@ jobs:
         if: always()
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.AI_PR_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
               owner: context.repo.owner,

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The MVP issue-to-PR automation is now implemented (Groq-backed).
 - Setup and testing guide: `docs/ai-issue-to-pr.md`
 - MVP definition: `docs/mvp.md`
 
-See `docs/ai-issue-to-pr.md` for required Groq secret + optional variables, label configuration, end-to-end test steps, and risk/mitigation notes.
+See `docs/ai-issue-to-pr.md` for required Groq secret, recommended PR token (`AI_PR_TOKEN`), optional variables, label configuration, end-to-end test steps, and risk/mitigation notes.
 
 
 ## Architecture Decisions

--- a/docs/adr/0004-pr-authentication-token-strategy.md
+++ b/docs/adr/0004-pr-authentication-token-strategy.md
@@ -1,0 +1,32 @@
+# ADR-0004: PR authentication token strategy
+
+- **Status:** Accepted
+- **Date:** 2026-04-14
+
+## Context
+
+The workflow opens pull requests from GitHub Actions (`.github/workflows/ai-issue-to-pr.yml`).
+Some repositories/organizations disable the setting that allows `GITHUB_TOKEN` to create or approve PRs.
+In that configuration, the run fails with:
+
+`GitHub Actions is not permitted to create or approve pull requests.`
+
+MVP still requires fail-fast behavior and deterministic PR creation when an issue is labeled `ai-task`.
+
+## Decision
+
+Use a dedicated secret token for PR-related writes when available:
+
+- Prefer `secrets.AI_PR_TOKEN`.
+- Fallback to `secrets.GITHUB_TOKEN` when `AI_PR_TOKEN` is not configured.
+
+Apply this strategy consistently to:
+
+- PR creation (`peter-evans/create-pull-request`).
+- Post-run label cleanup (`actions/github-script` for removing `ai-task`).
+
+## Consequences
+
+- Works in stricter org/repo policies without changing MVP orchestration.
+- Keeps backward compatibility for repositories that rely on `GITHUB_TOKEN`.
+- Requires setup documentation for `AI_PR_TOKEN` scopes and repository settings.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,3 +7,4 @@ Architecture Decision Records (ADR) for the MVP Issue → AI → PR automation.
 - [ADR-0001: Trigger policy and label gate](./0001-trigger-policy-and-label-gate.md)
 - [ADR-0002: AI provider choice (Groq)](./0002-ai-provider-groq.md)
 - [ADR-0003: Safe output scope (single generated file)](./0003-safe-output-scope.md)
+- [ADR-0004: PR authentication token strategy](./0004-pr-authentication-token-strategy.md)

--- a/docs/ai-issue-to-pr.md
+++ b/docs/ai-issue-to-pr.md
@@ -29,9 +29,23 @@ If generation fails or no patch is produced, the workflow exits before PR creati
 Configure these in **Settings → Secrets and variables → Actions**:
 
 - **Secret**: `GROQ_API_KEY` (required) — API key for Groq.
+- **Secret**: `AI_PR_TOKEN` (recommended) — GitHub token used for PR creation/issue label cleanup.
+  - Use a fine-grained PAT or GitHub App token with at least **Contents: Read/Write**, **Pull requests: Read/Write**, and **Issues: Read/Write** on this repository.
+  - If `AI_PR_TOKEN` is not set, the workflow falls back to `GITHUB_TOKEN`.
 - **Variables** (optional):
   - `GROQ_MODEL` — model name (defaults to `llama-3.1-8b-instant` if unset).
   - `GROQ_API_URL` — endpoint URL (defaults to `https://api.groq.com/openai/v1/chat/completions` if unset).
+
+## GitHub Actions PR Permission Requirement
+
+If the run fails with:
+
+`GitHub Actions is not permitted to create or approve pull requests.`
+
+you have two supported options:
+
+1. Enable repository setting **Settings → Actions → General → Workflow permissions → Allow GitHub Actions to create and approve pull requests**.
+2. Set `AI_PR_TOKEN` and keep the setting disabled (recommended for stricter org policies).
 
 ## Required Label
 


### PR DESCRIPTION
### Motivation
- The AI Issue-to-PR workflow can fail with `GitHub Actions is not permitted to create or approve pull requests` when repository/org policies block `GITHUB_TOKEN` from creating PRs. 
- Provide a supported alternative that keeps the existing fallback to `GITHUB_TOKEN` while allowing stricter org policies to use a dedicated token.

### Description
- Updated `.github/workflows/ai-issue-to-pr.yml` to use `secrets.AI_PR_TOKEN || secrets.GITHUB_TOKEN` for the `peter-evans/create-pull-request` step and for the `actions/github-script` `github-token` used during label cleanup. 
- Added `AI_PR_TOKEN` guidance to `docs/ai-issue-to-pr.md` including recommended minimal scopes (`Contents: Read/Write`, `Pull requests: Read/Write`, `Issues: Read/Write`) and the fallback behavior. 
- Documented the two supported ways to resolve the permission error: enable Actions PR creation in repo settings or supply `AI_PR_TOKEN` (recommended for stricter policies).

### Testing
- Verified the diffs with `git diff` to confirm the token substitution in `.github/workflows/ai-issue-to-pr.yml` and the docs additions in `docs/ai-issue-to-pr.md`, which succeeded. 
- Inspected the updated files with `nl -ba` to confirm the exact token references and documentation lines, which succeeded. 
- Committed the changes with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6bac195883258109eca6ee1be8af)