### PR TITLE
fix: limit ai-issue-to-pr output to a single requested file

### DIFF
--- a/.github/workflows/ai-issue-to-pr.yml
+++ b/.github/workflows/ai-issue-to-pr.yml
@@ -24,6 +24,7 @@ jobs:
           node-version: '20'
 
       - name: Generate AI change
+        id: generate
         env:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
@@ -32,16 +33,6 @@ jobs:
           GROQ_MODEL: ${{ vars.GROQ_MODEL }}
           GROQ_API_URL: ${{ vars.GROQ_API_URL }}
         run: node scripts/generate_issue_change.mjs
-
-      - name: Read generated summary
-        id: summary
-        shell: bash
-        run: |
-          {
-            echo "value<<EOF"
-            cat .ai-summary.txt
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
@@ -54,12 +45,11 @@ jobs:
           body: |
             ## AI Generated Change
 
-            ${{ steps.summary.outputs.value }}
+            ${{ steps.generate.outputs.summary }}
 
             Closes #${{ github.event.issue.number }}
           add-paths: |
-            ai-generated/issue-${{ github.event.issue.number }}.md
-            .ai-summary.txt
+            ${{ steps.generate.outputs.generated_path }}
 
       - name: Remove ai-task label
         if: always()

--- a/docs/adr/0003-safe-output-scope.md
+++ b/docs/adr/0003-safe-output-scope.md
@@ -9,8 +9,10 @@ MVP requires low-risk automated code changes and clear failure behavior.
 
 ## Decision
 
-Constrain generation to a single predictable file path:
-- `ai-generated/issue-<number>.md`
+Constrain generation to exactly one validated relative file path returned by AI:
+- no absolute paths
+- no `..` traversal
+- one file write per run
 
 The workflow fails fast and does not open a PR if AI call/validation/patch steps fail.
 

--- a/docs/ai-issue-to-pr.md
+++ b/docs/ai-issue-to-pr.md
@@ -16,7 +16,7 @@ When the `ai-task` label is added to an issue, the workflow:
 1. Runs only when the issue includes the `ai-task` label.
 2. Builds a deterministic prompt using issue number, title, and body.
 3. Calls the Groq API using repository secrets.
-4. Writes a minimal generated file at `ai-generated/issue-<number>.md`.
+4. Writes exactly one generated file at the AI-selected relative path (for example `helloworld.md`).
 5. Creates a branch named `ai/issue-<number>`.
 6. Uses `peter-evans/create-pull-request` to commit generated content on `ai/issue-<number>`.
 7. Opens a PR to the repository default branch with `Closes #<issue_number>`.
@@ -70,14 +70,14 @@ Only issues where this label is actively applied trigger the automation job.
 7. Confirm PR details:
    - title references the issue number/title
    - body includes generated summary and `Closes #<number>`
-   - changed file limited to `ai-generated/issue-<number>.md`
+   - changed files limited to a single AI-generated target file
 8. Confirm the issue label `ai-task` has been removed after the run completes.
 
 ## Limitations (MVP)
 
 - Triggers on issue label application events.
 - Only runs when the applied label name is exactly `ai-task`.
-- Applies a single small generated markdown file (safe scope).
+- Applies exactly one small generated file per run (safe scope).
 - Does not perform auto-merge.
 - Does not attempt multi-file or complex refactors.
 
@@ -86,6 +86,6 @@ Only issues where this label is actively applied trigger the automation job.
 - **Risk:** AI output may be low quality or off-target.
   - **Mitigation:** deterministic prompt template, temperature `0`, and small-scope generated file.
 - **Risk:** accidental broad modifications.
-  - **Mitigation:** generated patch is constrained to one predictable path (`ai-generated/issue-<number>.md`).
+  - **Mitigation:** generated patch is constrained to one validated relative path and one file write.
 - **Risk:** workflow secrets misconfiguration.
   - **Mitigation:** explicit secret checks and fail-fast logging before commit/PR steps.

--- a/scripts/generate_issue_change.mjs
+++ b/scripts/generate_issue_change.mjs
@@ -3,6 +3,7 @@
 import { buildDeterministicPrompt, loadConfigFromEnv } from './lib/config.mjs';
 import { callGroq } from './lib/groq_client.mjs';
 import { validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
+import fs from 'node:fs/promises';
 
 async function main() {
   const config = loadConfigFromEnv();
@@ -16,16 +17,18 @@ async function main() {
     apiUrl: config.apiUrl,
   });
 
-  const { summary, contentMarkdown } = validateAiOutput(aiOutput);
+  const { summary, targetPath, fileContent } = validateAiOutput(aiOutput);
   const outputPath = await writeGeneratedFiles({
-    issueNumber: config.issueNumber,
-    issueTitle: config.issueTitle,
-    summary,
-    contentMarkdown,
+    targetPath,
+    fileContent,
   });
 
+  if (process.env.GITHUB_OUTPUT) {
+    await fs.appendFile(process.env.GITHUB_OUTPUT, `summary<<EOF\n${summary}\nEOF\ngenerated_path=${outputPath}\n`, 'utf8');
+  }
+
   console.log(`[INFO] Wrote generated change: ${outputPath}`);
-  console.log('[INFO] Wrote PR summary helper: .ai-summary.txt');
+  console.log('[INFO] Exported workflow outputs: summary, generated_path');
 }
 
 main().catch((error) => {

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -27,7 +27,7 @@ export function loadConfigFromEnv() {
 
 export function buildDeterministicPrompt({ issueNumber, issueTitle, issueBody }) {
   return [
-    'Create a minimal, safe markdown draft for a pull request based on a GitHub issue.',
+    'Create exactly one repository file change from a GitHub issue.',
     '',
     'Deterministic issue data:',
     `- issue_number: ${issueNumber}`,
@@ -36,13 +36,15 @@ export function buildDeterministicPrompt({ issueNumber, issueTitle, issueBody })
     '',
     'Requirements:',
     '1) Keep scope small and non-destructive.',
-    '2) Produce markdown content only suitable for a single file update.',
-    '3) Be concise and actionable.',
+    '2) Propose exactly one file creation or update (never multiple files).',
+    '3) The path must be relative (no ../ and no absolute paths).',
+    '4) Return only the final file content, no surrounding explanations.',
     '',
     'Output JSON only:',
     '{',
     '  "summary": "One sentence summary of the generated change",',
-    '  "content_markdown": "Markdown body for the generated file"',
+    '  "target_path": "relative/path/to/file.ext",',
+    '  "file_content": "Exact content to write in the file"',
     '}',
   ].join('\n');
 }

--- a/scripts/lib/groq_client.mjs
+++ b/scripts/lib/groq_client.mjs
@@ -7,7 +7,7 @@ export async function callGroq({ prompt, apiKey, model, apiUrl }) {
       {
         role: 'system',
         content:
-          'You generate small, safe repository changes. Return strict JSON with keys summary and content_markdown.',
+          'You generate one small, safe repository file change. Return strict JSON with keys summary, target_path, and file_content.',
       },
       { role: 'user', content: prompt },
     ],

--- a/scripts/lib/output_writer.mjs
+++ b/scripts/lib/output_writer.mjs
@@ -1,29 +1,36 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 
 export function validateAiOutput(aiOutput) {
   const summary = String(aiOutput.summary || '').trim();
-  const contentMarkdown = String(aiOutput.content_markdown || '').trim();
+  const targetPath = String(aiOutput.target_path || '').trim();
+  const fileContent = String(aiOutput.file_content || '');
 
   if (!summary) {
     throw new Error('AI response missing non-empty summary');
   }
-  if (!contentMarkdown) {
-    throw new Error('AI response missing non-empty content_markdown');
+  if (!targetPath) {
+    throw new Error('AI response missing non-empty target_path');
   }
-  if (contentMarkdown.length > 8000) {
-    throw new Error('AI response content_markdown too large (>8000 chars)');
+  if (!fileContent.trim()) {
+    throw new Error('AI response missing non-empty file_content');
+  }
+  if (targetPath.startsWith('/') || targetPath.includes('..')) {
+    throw new Error('AI response target_path must be a safe relative path');
+  }
+  if (fileContent.length > 16000) {
+    throw new Error('AI response file_content too large (>16000 chars)');
   }
 
-  return { summary, contentMarkdown };
+  return { summary, targetPath, fileContent };
 }
 
-export async function writeGeneratedFiles({ issueNumber, issueTitle, summary, contentMarkdown }) {
-  const outputPath = `ai-generated/issue-${issueNumber}.md`;
-  const fileContent = `# AI Draft for Issue #${issueNumber}\n\n**Title:** ${issueTitle}\n\n## Generated Proposal\n\n${contentMarkdown}\n`;
-
-  await fs.mkdir('ai-generated', { recursive: true });
+export async function writeGeneratedFiles({ targetPath, fileContent }) {
+  const outputPath = path.normalize(targetPath).replaceAll('\\', '/');
+  const parentDir = path.dirname(outputPath);
+  if (parentDir && parentDir !== '.') {
+    await fs.mkdir(parentDir, { recursive: true });
+  }
   await fs.writeFile(outputPath, fileContent, 'utf8');
-  await fs.writeFile('.ai-summary.txt', `${summary}\n`, 'utf8');
-
   return outputPath;
 }


### PR DESCRIPTION
### Motivation
- The workflow produced an extra helper artifact (`.ai-summary.txt`) alongside the requested change, polluting PRs and increasing review surface. 
- The intent is to have the AI produce exactly one repository file per issue so PRs only contain the requested file (e.g., `helloworld.md`).
- Enforce a safer, explicit AI contract so generated changes are deterministic and constrained.

### Description
- Change the deterministic prompt and AI contract in `scripts/lib/config.mjs` to request `summary`, `target_path`, and `file_content` instead of `content_markdown`.
- Align the system message in `scripts/lib/groq_client.mjs` to require the new JSON keys `summary`, `target_path`, and `file_content`.
- Replace validation and output logic in `scripts/lib/output_writer.mjs` to validate a single safe relative `target_path`, require non-empty `file_content`, prevent `..`/absolute paths, and write exactly one file to the requested path.
- Update `scripts/generate_issue_change.mjs` to consume the new fields, write the single target file, and export `summary` and `generated_path` via `GITHUB_OUTPUT` instead of writing `.ai-summary.txt` into the repo.
- Update `.github/workflows/ai-issue-to-pr.yml` to use the `generate` step outputs for the PR body and `add-paths`, so the PR contains only the AI-selected file.
- Update documentation (`docs/ai-issue-to-pr.md`) and the ADR (`docs/adr/0003-safe-output-scope.md`) to describe the single validated file behavior.

### Testing
- Ran syntax checks with `node --check scripts/generate_issue_change.mjs && node --check scripts/lib/config.mjs && node --check scripts/lib/groq_client.mjs && node --check scripts/lib/output_writer.mjs`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7241864c8325b429e71e7051b444)