### PR TITLE
Add GitHub issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,34 @@
+---
+name: "🐞 Bug report"
+about: "Report a bug with context and acceptance criteria"
+title: "[BUG] "
+labels: ["ai-task"]
+assignees: []
+---
+
+## 🎯 Goal
+Fix a functional defect in a targeted and safe way.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Component:
+- Environment:
+
+## ❗ Observed problem
+Describe the current behavior and its impact precisely.
+
+## 🔁 Steps to reproduce
+1.
+2.
+3.
+
+## ✅ Expected behavior
+Describe the expected result.
+
+## 🧪 Acceptance criteria
+- [ ] Bug fixed
+- [ ] No side effects
+- [ ] Tests included
+
+## ⚠️ Constraints
+List constraints (API, schema, contracts, backward compatibility).

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,30 @@
+---
+name: "✨ Feature request"
+about: "Propose a new feature with clear scope"
+title: "[FEATURE] "
+labels: ["ai-task"]
+assignees: []
+---
+
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain:
+- Component:
+
+## 🚀 Description
+Describe what the feature does and the value it provides.
+
+## 🧩 Scope
+- In:
+- Out:
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+- [ ] Edge cases covered
+- [ ] Tests included
+
+## ⚙️ Constraints
+Describe constraints (performance, compatibility, security).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## 🎯 Goal
+Clearly describe what this PR delivers.
+
+## 📦 Changes
+- ...
+
+## 🧪 Validation
+- [ ] Tests pass
+- [ ] Tests added
+
+## ⚠️ Risks
+Describe potential impacts and mitigation plans.
+
+## 🔁 Checklist
+- [ ] Clean code
+- [ ] No duplication
+
+## 🧪 How to test
+1.
+2.
+3.


### PR DESCRIPTION
### Motivation
- Provide standardized templates to make bug reports, feature requests, and pull requests clearer and actionable.
- Encourage consistent metadata and acceptance criteria by adding structured forms and labels for issues and PRs.

### Description
- Add `./github/ISSUE_TEMPLATE/bug.md` which defines a bug report template with sections for goal, context, reproduction steps, expected behavior, and acceptance criteria. 
- Add `./github/ISSUE_TEMPLATE/feature.md` which defines a feature request template with goal, context, scope, and acceptance criteria.
- Add `./github/pull_request_template.md` which provides a PR checklist including goal, changes, validation, risks, and testing steps.

### Testing
- No automated tests were run because this is a documentation-only change consisting of template files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e006350c508325ae4cba8191ce1c30)