### PR TITLE
Add Groq-powered automated PR review workflow

### DIFF
--- a/.github/scripts/pr-review.mjs
+++ b/.github/scripts/pr-review.mjs
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+
+const e = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+const n = e.pull_request?.number; if (!n) throw new Error('Missing pull_request.number');
+const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+const h = { Authorization: `Bearer ${process.env.GITHUB_TOKEN}`, 'Content-Type': 'application/json', 'X-GitHub-Api-Version': '2022-11-28' };
+const gh = (u, o = {}) => fetch(`https://api.github.com${u}`, { ...o, headers: { ...h, ...(o.headers || {}) } });
+
+const dRes = await gh(`/repos/${owner}/${repo}/pulls/${n}`, { headers: { Accept: 'application/vnd.github.v3.diff' } });
+if (!dRes.ok) throw new Error(`Diff fetch failed: ${dRes.status}`);
+const raw = await dRes.text();
+const ign = /(\/|^)(node_modules|dist)\//;
+const lock = /(package-lock\.json|yarn\.lock|pnpm-lock\.ya?ml|bun\.lockb|Cargo\.lock|composer\.lock|poetry\.lock|Pipfile\.lock|Gemfile\.lock)$/;
+const kept = raw.split('\ndiff --git ').map((p, i) => (i ? `diff --git ${p}` : p)).filter(p => {
+  const m = p.match(/^diff --git a\/(.+?) b\//m); const f = m?.[1] || ''; return f && !ign.test(f) && !lock.test(f);
+}).join('\n');
+const diff = (kept || raw).slice(0, 12000);
+
+const system = 'You are a strict senior code reviewer.\n- No fluff\n- Only actionable issues\n- Be concise';
+const user = `Analyze this pull request diff:\n\n${diff}\n\nOutput:\n\n## 🔍 Automated Code Review\n\n### ✅ Summary\n(max 3 lines)\n\n### ⚠️ Issues Found\n- [High|Medium|Low] Description\n  File: <file>\n  Fix: <fix>\n\n### 💡 Suggestions\n(optional)\n\n### 🧪 Tests\n(missing or weak tests)\n\n### 🚀 Verdict\n(APPROVE | REQUEST_CHANGES | COMMENT)\n\nConstraints:\n- Max 300 words\n- No repetition`;
+const gRes = await fetch('https://api.groq.com/openai/v1/chat/completions', { method: 'POST', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${process.env.GROQ_API_KEY}` }, body: JSON.stringify({ model: 'llama3-70b-8192', temperature: 0.2, messages: [{ role: 'system', content: system }, { role: 'user', content: user }] }) });
+if (!gRes.ok) throw new Error(`Groq failed: ${gRes.status} ${await gRes.text()}`);
+const review = (await gRes.json())?.choices?.[0]?.message?.content?.trim();
+if (!review?.includes('## 🔍 Automated Code Review')) throw new Error('Groq output missing expected heading');
+
+const cRes = await gh(`/repos/${owner}/${repo}/issues/${n}/comments?per_page=100`); if (!cRes.ok) throw new Error(`Comment list failed: ${cRes.status}`);
+const comments = await cRes.json();
+const prior = comments.find(c => c.body?.includes('## 🔍 Automated Code Review'));
+const url = prior ? `/repos/${owner}/${repo}/issues/comments/${prior.id}` : `/repos/${owner}/${repo}/issues/${n}/comments`;
+const method = prior ? 'PATCH' : 'POST';
+const pRes = await gh(url, { method, body: JSON.stringify({ body: review }) });
+if (!pRes.ok) throw new Error(`Comment upsert failed: ${pRes.status} ${await pRes.text()}`);

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,21 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run automated review
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+        run: node .github/scripts/pr-review.mjs

--- a/docs/ai-issue-to-pr.md
+++ b/docs/ai-issue-to-pr.md
@@ -89,3 +89,13 @@ Only issues where this label is actively applied trigger the automation job.
   - **Mitigation:** generated patch is constrained to one validated relative path and one file write.
 - **Risk:** workflow secrets misconfiguration.
   - **Mitigation:** explicit secret checks and fail-fast logging before commit/PR steps.
+
+## PR Review Workflow (Groq)
+
+File: `.github/workflows/pr-review.yml`
+
+Required secret:
+- **Secret**: `GROQ_API_KEY` (required) — used to review pull request diffs and post/update a structured PR comment.
+
+The workflow runs on pull requests (`opened`, `synchronize`, `reopened`) with `pull-requests: write` and `contents: read`.
+


### PR DESCRIPTION
### Motivation
- Provide a fast, simple, stack-agnostic automated PR reviewer that produces concise, actionable feedback using Groq (LLaMA).
- Keep orchestration in a lightweight GitHub Actions workflow and put review logic in a small Node.js script for maintainability.
- Limit scope and risk by filtering generated files, truncating large diffs, and restricting workflow permissions.

### Description
- Add `.github/workflows/pr-review.yml` which runs on `pull_request` (`opened`, `synchronize`, `reopened`) with `pull-requests: write` and `contents: read` and a 2 minute job timeout.
- Add `.github/scripts/pr-review.mjs` which retrieves the PR diff via the GitHub API, filters out `node_modules`, `dist`, and common lock files, truncates the payload to ~12k characters, and posts it to Groq at `https://api.groq.com/openai/v1/chat/completions` using `llama3-70b-8192` and `temperature: 0.2`.
- The script validates the model response contains the heading `## 🔍 Automated Code Review` and creates or updates the PR comment (matching that heading) via the Issues API.
- Update `docs/ai-issue-to-pr.md` to document the new PR review workflow and the required `GROQ_API_KEY` secret.

### Testing
- Ran `node --check .github/scripts/pr-review.mjs` to verify the reviewer script is syntactically valid, and it succeeded.
- Verified file additions with `wc -l .github/workflows/pr-review.yml .github/scripts/pr-review.mjs` to confirm expected files were created, and the command completed successfully.
- The workflow is designed to run within the 2 minute timeout and requires `GITHUB_TOKEN` and `GROQ_API_KEY` as environment secrets for operation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e011c453b08325b0eb1de54df430ad)