### PR TITLE
Add unit tests for all core modules with CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node --test scripts/tests/*.test.mjs"
+  }
+}

--- a/scripts/lib/groq_client.mjs
+++ b/scripts/lib/groq_client.mjs
@@ -46,7 +46,7 @@ export async function callGroq({ prompt, apiKey, model, apiUrl }) {
     throw new Error('AI response was not valid JSON');
   }
 
-  if (!parsed || typeof parsed !== 'object') {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('AI response JSON must be an object');
   }
 

--- a/scripts/tests/config.test.mjs
+++ b/scripts/tests/config.test.mjs
@@ -1,0 +1,97 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { requireEnv, loadConfigFromEnv, buildDeterministicPrompt } from '../lib/config.mjs';
+
+const REQUIRED_VARS = ['ISSUE_NUMBER', 'ISSUE_TITLE', 'GROQ_API_KEY'];
+
+function setEnv(vars) {
+  for (const [k, v] of Object.entries(vars)) process.env[k] = v;
+}
+
+function unsetEnv(...names) {
+  for (const name of names) delete process.env[name];
+}
+
+beforeEach(() => unsetEnv(...REQUIRED_VARS, 'ISSUE_BODY', 'GROQ_MODEL', 'GROQ_API_URL'));
+afterEach(() => unsetEnv(...REQUIRED_VARS, 'ISSUE_BODY', 'GROQ_MODEL', 'GROQ_API_URL'));
+
+// requireEnv
+
+test('requireEnv returns trimmed value when set', () => {
+  process.env.TEST_VAR = '  hello  ';
+  assert.equal(requireEnv('TEST_VAR'), 'hello');
+  delete process.env.TEST_VAR;
+});
+
+test('requireEnv throws when variable is missing', () => {
+  delete process.env.TEST_VAR;
+  assert.throws(() => requireEnv('TEST_VAR'), /Missing required environment variable: TEST_VAR/);
+});
+
+test('requireEnv throws when variable is empty string', () => {
+  process.env.TEST_VAR = '   ';
+  assert.throws(() => requireEnv('TEST_VAR'), /Missing required environment variable: TEST_VAR/);
+  delete process.env.TEST_VAR;
+});
+
+// loadConfigFromEnv
+
+test('loadConfigFromEnv returns full config with all vars set', () => {
+  setEnv({ ISSUE_NUMBER: '7', ISSUE_TITLE: 'Fix bug', ISSUE_BODY: 'Details', GROQ_API_KEY: 'key123' });
+  const config = loadConfigFromEnv();
+  assert.equal(config.issueNumber, '7');
+  assert.equal(config.issueTitle, 'Fix bug');
+  assert.equal(config.issueBody, 'Details');
+  assert.equal(config.apiKey, 'key123');
+  assert.equal(config.model, 'llama-3.1-8b-instant');
+});
+
+test('loadConfigFromEnv uses default model when GROQ_MODEL not set', () => {
+  setEnv({ ISSUE_NUMBER: '1', ISSUE_TITLE: 'T', GROQ_API_KEY: 'k' });
+  const { model } = loadConfigFromEnv();
+  assert.equal(model, 'llama-3.1-8b-instant');
+});
+
+test('loadConfigFromEnv uses custom model when GROQ_MODEL is set', () => {
+  setEnv({ ISSUE_NUMBER: '1', ISSUE_TITLE: 'T', GROQ_API_KEY: 'k', GROQ_MODEL: 'llama-3-70b' });
+  const { model } = loadConfigFromEnv();
+  assert.equal(model, 'llama-3-70b');
+});
+
+test('loadConfigFromEnv defaults ISSUE_BODY when not set', () => {
+  setEnv({ ISSUE_NUMBER: '1', ISSUE_TITLE: 'T', GROQ_API_KEY: 'k' });
+  const { issueBody } = loadConfigFromEnv();
+  assert.equal(issueBody, '(no body provided)');
+});
+
+test('loadConfigFromEnv throws when GROQ_API_KEY is missing', () => {
+  setEnv({ ISSUE_NUMBER: '1', ISSUE_TITLE: 'T' });
+  assert.throws(() => loadConfigFromEnv(), /GROQ_API_KEY/);
+});
+
+test('loadConfigFromEnv throws when ISSUE_NUMBER is missing', () => {
+  setEnv({ ISSUE_TITLE: 'T', GROQ_API_KEY: 'k' });
+  assert.throws(() => loadConfigFromEnv(), /ISSUE_NUMBER/);
+});
+
+// buildDeterministicPrompt
+
+test('buildDeterministicPrompt includes issue fields', () => {
+  const prompt = buildDeterministicPrompt({ issueNumber: '42', issueTitle: 'Add docs', issueBody: 'Please add docs' });
+  assert.ok(prompt.includes('42'));
+  assert.ok(prompt.includes('Add docs'));
+  assert.ok(prompt.includes('Please add docs'));
+});
+
+test('buildDeterministicPrompt contains JSON output schema keys', () => {
+  const prompt = buildDeterministicPrompt({ issueNumber: '1', issueTitle: 'T', issueBody: 'B' });
+  assert.ok(prompt.includes('summary'));
+  assert.ok(prompt.includes('target_path'));
+  assert.ok(prompt.includes('file_content'));
+});
+
+test('buildDeterministicPrompt returns a non-empty string', () => {
+  const prompt = buildDeterministicPrompt({ issueNumber: '1', issueTitle: 'T', issueBody: 'B' });
+  assert.equal(typeof prompt, 'string');
+  assert.ok(prompt.length > 0);
+});

--- a/scripts/tests/groq_client.test.mjs
+++ b/scripts/tests/groq_client.test.mjs
@@ -1,0 +1,80 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { callGroq } from '../lib/groq_client.mjs';
+
+const BASE_ARGS = { prompt: 'go', apiKey: 'key', model: 'llama-3.1-8b-instant', apiUrl: 'https://api.test' };
+
+function makeResponse(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+function mockFetch(response) {
+  globalThis.fetch = async () => response;
+}
+
+afterEach(() => { delete globalThis.fetch; });
+
+test('callGroq returns parsed AI object on success', async () => {
+  const aiContent = { summary: 'S', target_path: 'a.md', file_content: 'hello' };
+  mockFetch(makeResponse({
+    choices: [{ message: { content: JSON.stringify(aiContent) } }],
+  }));
+  const result = await callGroq(BASE_ARGS);
+  assert.deepEqual(result, aiContent);
+});
+
+test('callGroq throws on HTTP error status', async () => {
+  mockFetch(makeResponse('Unauthorized', 401));
+  await assert.rejects(() => callGroq(BASE_ARGS), /Groq API HTTP error 401/);
+});
+
+test('callGroq throws when response body is not JSON', async () => {
+  globalThis.fetch = async () => ({ ok: true, status: 200, text: async () => 'not-json' });
+  await assert.rejects(() => callGroq(BASE_ARGS), /non-JSON response/);
+});
+
+test('callGroq throws when choices array is missing', async () => {
+  mockFetch(makeResponse({ choices: [] }));
+  await assert.rejects(() => callGroq(BASE_ARGS), /Unexpected Groq API response format/);
+});
+
+test('callGroq throws when message content is missing', async () => {
+  mockFetch(makeResponse({ choices: [{ message: {} }] }));
+  await assert.rejects(() => callGroq(BASE_ARGS), /Unexpected Groq API response format/);
+});
+
+test('callGroq throws when AI content is not valid JSON', async () => {
+  mockFetch(makeResponse({ choices: [{ message: { content: 'not json' } }] }));
+  await assert.rejects(() => callGroq(BASE_ARGS), /not valid JSON/);
+});
+
+test('callGroq throws when AI content is a JSON array (not object)', async () => {
+  mockFetch(makeResponse({ choices: [{ message: { content: '[]' } }] }));
+  await assert.rejects(() => callGroq(BASE_ARGS), /must be an object/);
+});
+
+test('callGroq sends correct Authorization header', async () => {
+  let capturedHeaders;
+  const aiContent = { summary: 'S', target_path: 'a.md', file_content: 'x' };
+  globalThis.fetch = async (_url, opts) => {
+    capturedHeaders = opts.headers;
+    return makeResponse({ choices: [{ message: { content: JSON.stringify(aiContent) } }] });
+  };
+  await callGroq(BASE_ARGS);
+  assert.equal(capturedHeaders['Authorization'], 'Bearer key');
+});
+
+test('callGroq sends temperature 0 in payload', async () => {
+  let capturedBody;
+  const aiContent = { summary: 'S', target_path: 'a.md', file_content: 'x' };
+  globalThis.fetch = async (_url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return makeResponse({ choices: [{ message: { content: JSON.stringify(aiContent) } }] });
+  };
+  await callGroq(BASE_ARGS);
+  assert.equal(capturedBody.temperature, 0);
+});

--- a/scripts/tests/output_writer.test.mjs
+++ b/scripts/tests/output_writer.test.mjs
@@ -1,0 +1,81 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { validateAiOutput } from '../lib/output_writer.mjs';
+
+test('validateAiOutput returns trimmed fields for valid input', () => {
+  const result = validateAiOutput({
+    summary: '  Add readme  ',
+    target_path: 'docs/readme.md',
+    file_content: '# Hello',
+  });
+  assert.equal(result.summary, 'Add readme');
+  assert.equal(result.targetPath, 'docs/readme.md');
+  assert.equal(result.fileContent, '# Hello');
+});
+
+test('validateAiOutput throws when summary is missing', () => {
+  assert.throws(
+    () => validateAiOutput({ summary: '', target_path: 'a.md', file_content: 'x' }),
+    /missing non-empty summary/,
+  );
+});
+
+test('validateAiOutput throws when target_path is missing', () => {
+  assert.throws(
+    () => validateAiOutput({ summary: 'ok', target_path: '', file_content: 'x' }),
+    /missing non-empty target_path/,
+  );
+});
+
+test('validateAiOutput throws when file_content is blank', () => {
+  assert.throws(
+    () => validateAiOutput({ summary: 'ok', target_path: 'a.md', file_content: '   ' }),
+    /missing non-empty file_content/,
+  );
+});
+
+test('validateAiOutput throws for absolute path', () => {
+  assert.throws(
+    () => validateAiOutput({ summary: 'ok', target_path: '/etc/passwd', file_content: 'x' }),
+    /safe relative path/,
+  );
+});
+
+test('validateAiOutput throws for path with ..', () => {
+  assert.throws(
+    () => validateAiOutput({ summary: 'ok', target_path: '../outside/file.md', file_content: 'x' }),
+    /safe relative path/,
+  );
+});
+
+test('validateAiOutput throws for embedded .. traversal', () => {
+  assert.throws(
+    () => validateAiOutput({ summary: 'ok', target_path: 'docs/../../etc/passwd', file_content: 'x' }),
+    /safe relative path/,
+  );
+});
+
+test('validateAiOutput throws when file_content exceeds 16000 chars', () => {
+  assert.throws(
+    () => validateAiOutput({ summary: 'ok', target_path: 'a.md', file_content: 'x'.repeat(16001) }),
+    /too large/,
+  );
+});
+
+test('validateAiOutput accepts file_content exactly at 16000 chars', () => {
+  const result = validateAiOutput({
+    summary: 'ok',
+    target_path: 'a.md',
+    file_content: 'x'.repeat(16000),
+  });
+  assert.equal(result.fileContent.length, 16000);
+});
+
+test('validateAiOutput coerces non-string fields to strings', () => {
+  const result = validateAiOutput({
+    summary: 42,
+    target_path: 'a.md',
+    file_content: true,
+  });
+  assert.equal(result.summary, '42');
+});


### PR DESCRIPTION
Adds 31 tests covering validateAiOutput (path safety, size limits,
field validation), loadConfigFromEnv/buildDeterministicPrompt, and
callGroq (HTTP errors, malformed responses, payload correctness).
Also fixes groq_client to correctly reject JSON arrays as AI output.

https://claude.ai/code/session_01BCDfh117UodUE3k5fjh6pF