### PR TITLE
docs: align workflow trigger and prompt path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The MVP issue-to-PR automation is now implemented (Groq-backed).
 - Workflow: `.github/workflows/ai-issue-to-pr.yml` (kept minimal/orchestration-only)
 - Generator script: `scripts/generate_issue_change.mjs`
 - Generator modules: `scripts/lib/*.mjs`
-- Prompt files: `prompts/*.txt` (one file per prompt, loaded at runtime)
+- Prompt files: `prompts/*.md` (one file per prompt, loaded at runtime)
 - Setup and testing guide: `docs/ai-issue-to-pr.md`
 - MVP definition: `docs/mvp.md`
 

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -1,7 +1,7 @@
 # MVP: AI-Assisted Issue-to-PR Workflow
 
 ## Objective
-Build a minimal automation flow where creating a new GitHub issue triggers a workflow that:
+Build a minimal automation flow where explicitly labeling a GitHub issue with `ai-task` triggers a workflow that:
 1. Sends a prompt to an AI model.
 2. Uses the AI response to implement a small code/documentation change.
 3. Opens a simple pull request automatically.
@@ -15,7 +15,7 @@ Teams lose time on repetitive starter tasks (small fixes, doc updates, scaffoldi
 - Projects where quick first-draft PRs reduce cycle time.
 
 ## In-Scope (MVP)
-- Trigger on **new issue** event.
+- Trigger on **issue labeled** event, gated to the `ai-task` label.
 - Build a prompt from issue title + body.
 - Call an AI model with that prompt.
 - Create/modify files in a dedicated branch.
@@ -30,7 +30,7 @@ Teams lose time on repetitive starter tasks (small fixes, doc updates, scaffoldi
 - Multi-model orchestration.
 
 ## Functional Requirements
-1. On issue creation, workflow runs once.
+1. On `issues.labeled`, workflow runs only when the applied label is `ai-task`.
 2. Workflow sends deterministic prompt template to AI.
 3. AI output is applied as a minimal patch.
 4. Branch naming follows convention (e.g., `ai/issue-<number>`).
@@ -62,6 +62,6 @@ Teams lose time on repetitive starter tasks (small fixes, doc updates, scaffoldi
   - **Mitigation:** retries + clear failure notifications.
 
 ## Next Steps
-- Define the exact issue label(s) eligible for automation.
-- Finalize prompt template and output format contract.
-- Implement GitHub Actions workflow and pilot with test issues.
+- Improve issue validation guidance and reviewer feedback loops for low-scoring tasks.
+- Add additional safety policies while preserving the single-file MVP scope.
+- Pilot with larger issue samples and track quality metrics against acceptance criteria.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,8 +30,8 @@ All AI prompts live in `prompts/` as `.md` files, one per prompt:
 | `validation-user.md` | `issue_validator.mjs` | Placeholders: `{{issueTitle}}`, `{{issueBody}}` |
 | `generation-system.md` | `generate_issue_change.mjs` | System instruction for code generation |
 | `generation-user.md` | `config.mjs` | Placeholders: `{{issueNumber}}`, `{{issueTitle}}`, `{{issueBody}}` |
-| `pr-review-system.md` | `.github/scripts/pr-review.mjs` | Reviewer persona |
-| `pr-review-user.md` | `.github/scripts/pr-review.mjs` | Placeholder: `{{diff}}` |
+| `pr-review-system.md` | `scripts/pr_review.mjs` | Reviewer persona |
+| `pr-review-user.md` | `scripts/pr_review.mjs` | Placeholder: `{{diff}}` |
 
 Template placeholders use the `{{variableName}}` syntax. `interpolatePrompt()` in `scripts/lib/prompts.mjs` handles substitution; unknown placeholders are left unchanged.
 


### PR DESCRIPTION
### Motivation
- Fix documentation inconsistencies so the README/MVP/testing docs accurately reflect the implemented workflows, scripts, and prompt file formats.

### Description
- Update `README.md` to reference `prompts/*.md` which matches the repository prompt files.
- Update `docs/testing.md` to point the PR-review prompt consumers at `scripts/pr_review.mjs` instead of the incorrect path.
- Update `docs/mvp.md` to describe the actual label-gated trigger (`issues.labeled` gated to the `ai-task` label) and refresh the Next Steps to match the current implementation.

### Testing
- Ran `npm test` via `node --test scripts/tests/*.test.mjs` and all unit tests passed (112 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e819effc9c83258ac94676354a905c)