### PR TITLE
feat: gate AI issue-to-PR on validated issues and support multi-file generation

### DIFF
--- a/.github/workflows/ai-issue-to-pr.yml
+++ b/.github/workflows/ai-issue-to-pr.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   generate-pr:
-    if: github.event.label.name == 'ai-task'
+    if: github.event.label.name == 'ai-task' && contains(github.event.issue.labels.*.name, 'ready-for-dev')
     runs-on: ubuntu-latest
 
     steps:
@@ -49,7 +49,7 @@ jobs:
 
             Closes #${{ github.event.issue.number }}
           add-paths: |
-            ${{ steps.generate.outputs.generated_path }}
+            ${{ steps.generate.outputs.generated_paths }}
 
       - name: Remove ai-task label
         if: always()

--- a/docs/ai-issue-to-pr.md
+++ b/docs/ai-issue-to-pr.md
@@ -1,6 +1,6 @@
 # AI Issue-to-PR MVP Setup (Groq)
 
-This repository includes an MVP workflow that converts issues labeled with `ai-task` into AI-generated draft pull requests using Groq.
+This repository includes an MVP workflow that converts issues labeled with `ai-task` into AI-generated draft pull requests using Groq, but only after the validation agent has added the `ready-for-dev` label.
 
 ## Workflow Overview
 
@@ -13,10 +13,10 @@ Node implementation:
 - Modules: `scripts/lib/config.mjs`, `scripts/lib/groq_client.mjs`, `scripts/lib/output_writer.mjs`
 
 When the `ai-task` label is added to an issue, the workflow:
-1. Runs only when the issue includes the `ai-task` label.
+1. Runs only when the applied label is `ai-task` **and** the issue already has `ready-for-dev` (set by the validation agent).
 2. Builds a deterministic prompt using issue number, title, and body.
 3. Calls the Groq API using repository secrets.
-4. Writes exactly one generated file at the AI-selected relative path (for example `helloworld.md`).
+4. Writes 1 to 3 generated files at AI-selected relative paths.
 5. Creates a branch named `ai/issue-<number>`.
 6. Uses `peter-evans/create-pull-request` to commit generated content on `ai/issue-<number>`.
 7. Opens a PR to the repository default branch with `Closes #<issue_number>`.
@@ -49,11 +49,12 @@ you have two supported options:
 
 ## Required Label
 
-Create and use this issue label:
+Create and use these issue labels:
 
+- `ready-for-dev` (applied by the validation workflow when issue quality is sufficient)
 - `ai-task`
 
-Only issues where this label is actively applied trigger the automation job.
+`AI Issue to PR` only runs when `ai-task` is applied to an issue that already has `ready-for-dev`.
 
 ## End-to-End Test
 
@@ -70,14 +71,14 @@ Only issues where this label is actively applied trigger the automation job.
 7. Confirm PR details:
    - title references the issue number/title
    - body includes generated summary and `Closes #<number>`
-   - changed files limited to a single AI-generated target file
+   - changed files are limited to the generated AI target paths (maximum 3 files)
 8. Confirm the issue label `ai-task` has been removed after the run completes.
 
 ## Limitations (MVP)
 
 - Triggers on issue label application events.
 - Only runs when the applied label name is exactly `ai-task`.
-- Applies exactly one small generated file per run (safe scope).
+- Applies 1 to 3 small generated files per run (safe scope).
 - Does not perform auto-merge.
 - Does not attempt multi-file or complex refactors.
 
@@ -86,7 +87,7 @@ Only issues where this label is actively applied trigger the automation job.
 - **Risk:** AI output may be low quality or off-target.
   - **Mitigation:** deterministic prompt template, temperature `0`, and small-scope generated file.
 - **Risk:** accidental broad modifications.
-  - **Mitigation:** generated patch is constrained to one validated relative path and one file write.
+  - **Mitigation:** generated patch is constrained to validated relative paths with a hard limit of 3 files per run.
 - **Risk:** workflow secrets misconfiguration.
   - **Mitigation:** explicit secret checks and fail-fast logging before commit/PR steps.
 

--- a/prompts/generation-system.md
+++ b/prompts/generation-system.md
@@ -1,1 +1,1 @@
-You generate one small, safe repository file change. Return strict JSON with keys summary, target_path, and file_content.
+You generate small, safe repository changes. Return strict JSON with keys summary and changes. The changes field must be an array of objects, each with target_path and file_content.

--- a/prompts/generation-user.md
+++ b/prompts/generation-user.md
@@ -1,4 +1,4 @@
-Create exactly one repository file change from a GitHub issue.
+Create a small, safe repository patch from a GitHub issue.
 
 Deterministic issue data:
 - issue_number: {{issueNumber}}
@@ -7,13 +7,18 @@ Deterministic issue data:
 
 Requirements:
 1) Keep scope small and non-destructive.
-2) Propose exactly one file creation or update (never multiple files).
-3) The path must be relative (no ../ and no absolute paths).
-4) Return only the final file content, no surrounding explanations.
+2) Propose 1 to 3 file creations/updates based on the issue (never more than 3 files).
+3) Prefer focused, coherent changes over broad refactors.
+4) Every path must be relative (no ../ and no absolute paths).
+5) Return only final file contents, no surrounding explanations.
 
 Output JSON only:
 {
   "summary": "One sentence summary of the generated change",
-  "target_path": "relative/path/to/file.ext",
-  "file_content": "Exact content to write in the file"
+  "changes": [
+    {
+      "target_path": "relative/path/to/file.ext",
+      "file_content": "Exact content to write in the file"
+    }
+  ]
 }

--- a/prompts/generation-user.md
+++ b/prompts/generation-user.md
@@ -7,10 +7,13 @@ Deterministic issue data:
 
 Requirements:
 1) Keep scope small and non-destructive.
-2) Propose 1 to 3 file creations/updates based on the issue (never more than 3 files).
-3) Prefer focused, coherent changes over broad refactors.
-4) Every path must be relative (no ../ and no absolute paths).
-5) Return only final file contents, no surrounding explanations.
+2) Modify existing files when possible. Only create new files if strictly necessary.
+3) Propose 1 to 3 file creations/updates (never more than 3 files).
+4) Changes must directly address the issue. No speculative improvements.
+5) Prefer focused, coherent changes over broad refactors.
+6) Generated code must be syntactically valid and consistent. No unresolved imports or references.
+7) Every path must be relative (no ../ and no absolute paths).
+8) Do not add explanations, comments, or metadata outside the required output.
 
 Output JSON only:
 {

--- a/scripts/generate_issue_change.mjs
+++ b/scripts/generate_issue_change.mjs
@@ -30,18 +30,19 @@ async function main() {
     throw new Error('AI response JSON must be an object');
   }
 
-  const { summary, targetPath, fileContent } = validateAiOutput(aiOutput);
-  const outputPath = await writeGeneratedFiles({
-    targetPath,
-    fileContent,
-  });
+  const { summary, changes } = validateAiOutput(aiOutput);
+  const outputPaths = await writeGeneratedFiles(changes);
 
   if (process.env.GITHUB_OUTPUT) {
-    await fs.appendFile(process.env.GITHUB_OUTPUT, `summary<<EOF\n${summary}\nEOF\ngenerated_path=${outputPath}\n`, 'utf8');
+    await fs.appendFile(
+      process.env.GITHUB_OUTPUT,
+      `summary<<EOF\n${summary}\nEOF\ngenerated_paths<<EOF\n${outputPaths.join('\n')}\nEOF\n`,
+      'utf8',
+    );
   }
 
-  console.log(`[INFO] Wrote generated change: ${outputPath}`);
-  console.log('[INFO] Exported workflow outputs: summary, generated_path');
+  console.log(`[INFO] Wrote generated changes: ${outputPaths.join(', ')}`);
+  console.log('[INFO] Exported workflow outputs: summary, generated_paths');
 }
 
 main().catch((error) => {

--- a/scripts/lib/output_writer.mjs
+++ b/scripts/lib/output_writer.mjs
@@ -1,36 +1,68 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+const MAX_FILE_COUNT = 3;
+const MAX_FILE_CONTENT_LENGTH = 16000;
+
+function validateSingleChange(change, index) {
+  if (!change || typeof change !== 'object' || Array.isArray(change)) {
+    throw new Error(`AI response changes[${index}] must be an object`);
+  }
+
+  const targetPath = String(change.target_path || '').trim();
+  const fileContent = String(change.file_content || '');
+
+  if (!targetPath) {
+    throw new Error(`AI response changes[${index}] missing non-empty target_path`);
+  }
+  if (!fileContent.trim()) {
+    throw new Error(`AI response changes[${index}] missing non-empty file_content`);
+  }
+  if (targetPath.startsWith('/') || targetPath.includes('..')) {
+    throw new Error(`AI response changes[${index}] target_path must be a safe relative path`);
+  }
+  if (fileContent.length > MAX_FILE_CONTENT_LENGTH) {
+    throw new Error(`AI response changes[${index}] file_content too large (>16000 chars)`);
+  }
+
+  return { targetPath, fileContent };
+}
+
 export function validateAiOutput(aiOutput) {
   const summary = String(aiOutput.summary || '').trim();
-  const targetPath = String(aiOutput.target_path || '').trim();
-  const fileContent = String(aiOutput.file_content || '');
+  const changes = aiOutput.changes;
 
   if (!summary) {
     throw new Error('AI response missing non-empty summary');
   }
-  if (!targetPath) {
-    throw new Error('AI response missing non-empty target_path');
+  if (!Array.isArray(changes) || changes.length === 0) {
+    throw new Error('AI response missing non-empty changes array');
   }
-  if (!fileContent.trim()) {
-    throw new Error('AI response missing non-empty file_content');
-  }
-  if (targetPath.startsWith('/') || targetPath.includes('..')) {
-    throw new Error('AI response target_path must be a safe relative path');
-  }
-  if (fileContent.length > 16000) {
-    throw new Error('AI response file_content too large (>16000 chars)');
+  if (changes.length > MAX_FILE_COUNT) {
+    throw new Error('AI response changes array too large (>3 files)');
   }
 
-  return { summary, targetPath, fileContent };
+  const normalizedChanges = changes.map((change, index) => validateSingleChange(change, index));
+  const uniquePathCount = new Set(normalizedChanges.map(({ targetPath }) => targetPath)).size;
+  if (uniquePathCount !== normalizedChanges.length) {
+    throw new Error('AI response changes contain duplicate target_path values');
+  }
+
+  return { summary, changes: normalizedChanges };
 }
 
-export async function writeGeneratedFiles({ targetPath, fileContent }) {
-  const outputPath = path.normalize(targetPath).replaceAll('\\', '/');
-  const parentDir = path.dirname(outputPath);
-  if (parentDir && parentDir !== '.') {
-    await fs.mkdir(parentDir, { recursive: true });
+export async function writeGeneratedFiles(changes) {
+  const writtenPaths = [];
+
+  for (const { targetPath, fileContent } of changes) {
+    const outputPath = path.normalize(targetPath).replaceAll('\\', '/');
+    const parentDir = path.dirname(outputPath);
+    if (parentDir && parentDir !== '.') {
+      await fs.mkdir(parentDir, { recursive: true });
+    }
+    await fs.writeFile(outputPath, fileContent, 'utf8');
+    writtenPaths.push(outputPath);
   }
-  await fs.writeFile(outputPath, fileContent, 'utf8');
-  return outputPath;
+
+  return writtenPaths;
 }

--- a/scripts/tests/config.test.mjs
+++ b/scripts/tests/config.test.mjs
@@ -86,6 +86,7 @@ test('buildDeterministicPrompt includes issue fields', () => {
 test('buildDeterministicPrompt contains JSON output schema keys', () => {
   const prompt = buildDeterministicPrompt({ issueNumber: '1', issueTitle: 'T', issueBody: 'B' });
   assert.ok(prompt.includes('summary'));
+  assert.ok(prompt.includes('changes'));
   assert.ok(prompt.includes('target_path'));
   assert.ok(prompt.includes('file_content'));
 });

--- a/scripts/tests/output_writer.test.mjs
+++ b/scripts/tests/output_writer.test.mjs
@@ -4,60 +4,82 @@ import { validateAiOutput } from '../lib/output_writer.mjs';
 
 test('validateAiOutput returns trimmed fields for valid input', () => {
   const result = validateAiOutput({
-    summary: '  Add readme  ',
-    target_path: 'docs/readme.md',
-    file_content: '# Hello',
+    summary: '  Add docs update  ',
+    changes: [{ target_path: 'docs/readme.md', file_content: '# Hello' }],
   });
-  assert.equal(result.summary, 'Add readme');
-  assert.equal(result.targetPath, 'docs/readme.md');
-  assert.equal(result.fileContent, '# Hello');
+  assert.equal(result.summary, 'Add docs update');
+  assert.equal(result.changes.length, 1);
+  assert.equal(result.changes[0].targetPath, 'docs/readme.md');
+  assert.equal(result.changes[0].fileContent, '# Hello');
 });
 
 test('validateAiOutput throws when summary is missing', () => {
   assert.throws(
-    () => validateAiOutput({ summary: '', target_path: 'a.md', file_content: 'x' }),
+    () => validateAiOutput({ summary: '', changes: [{ target_path: 'a.md', file_content: 'x' }] }),
     /missing non-empty summary/,
+  );
+});
+
+test('validateAiOutput throws when changes is missing', () => {
+  assert.throws(
+    () => validateAiOutput({ summary: 'ok', changes: [] }),
+    /missing non-empty changes array/,
+  );
+});
+
+test('validateAiOutput throws when changes contains more than 3 files', () => {
+  assert.throws(
+    () => validateAiOutput({
+      summary: 'ok',
+      changes: [
+        { target_path: 'a.md', file_content: 'x' },
+        { target_path: 'b.md', file_content: 'x' },
+        { target_path: 'c.md', file_content: 'x' },
+        { target_path: 'd.md', file_content: 'x' },
+      ],
+    }),
+    /too large/,
   );
 });
 
 test('validateAiOutput throws when target_path is missing', () => {
   assert.throws(
-    () => validateAiOutput({ summary: 'ok', target_path: '', file_content: 'x' }),
+    () => validateAiOutput({ summary: 'ok', changes: [{ target_path: '', file_content: 'x' }] }),
     /missing non-empty target_path/,
   );
 });
 
 test('validateAiOutput throws when file_content is blank', () => {
   assert.throws(
-    () => validateAiOutput({ summary: 'ok', target_path: 'a.md', file_content: '   ' }),
+    () => validateAiOutput({ summary: 'ok', changes: [{ target_path: 'a.md', file_content: '   ' }] }),
     /missing non-empty file_content/,
   );
 });
 
 test('validateAiOutput throws for absolute path', () => {
   assert.throws(
-    () => validateAiOutput({ summary: 'ok', target_path: '/etc/passwd', file_content: 'x' }),
+    () => validateAiOutput({ summary: 'ok', changes: [{ target_path: '/etc/passwd', file_content: 'x' }] }),
     /safe relative path/,
   );
 });
 
 test('validateAiOutput throws for path with ..', () => {
   assert.throws(
-    () => validateAiOutput({ summary: 'ok', target_path: '../outside/file.md', file_content: 'x' }),
+    () => validateAiOutput({ summary: 'ok', changes: [{ target_path: '../outside/file.md', file_content: 'x' }] }),
     /safe relative path/,
   );
 });
 
 test('validateAiOutput throws for embedded .. traversal', () => {
   assert.throws(
-    () => validateAiOutput({ summary: 'ok', target_path: 'docs/../../etc/passwd', file_content: 'x' }),
+    () => validateAiOutput({ summary: 'ok', changes: [{ target_path: 'docs/../../etc/passwd', file_content: 'x' }] }),
     /safe relative path/,
   );
 });
 
 test('validateAiOutput throws when file_content exceeds 16000 chars', () => {
   assert.throws(
-    () => validateAiOutput({ summary: 'ok', target_path: 'a.md', file_content: 'x'.repeat(16001) }),
+    () => validateAiOutput({ summary: 'ok', changes: [{ target_path: 'a.md', file_content: 'x'.repeat(16001) }] }),
     /too large/,
   );
 });
@@ -65,17 +87,29 @@ test('validateAiOutput throws when file_content exceeds 16000 chars', () => {
 test('validateAiOutput accepts file_content exactly at 16000 chars', () => {
   const result = validateAiOutput({
     summary: 'ok',
-    target_path: 'a.md',
-    file_content: 'x'.repeat(16000),
+    changes: [{ target_path: 'a.md', file_content: 'x'.repeat(16000) }],
   });
-  assert.equal(result.fileContent.length, 16000);
+  assert.equal(result.changes[0].fileContent.length, 16000);
 });
 
 test('validateAiOutput coerces non-string fields to strings', () => {
   const result = validateAiOutput({
     summary: 42,
-    target_path: 'a.md',
-    file_content: true,
+    changes: [{ target_path: 'a.md', file_content: true }],
   });
   assert.equal(result.summary, '42');
+  assert.equal(result.changes[0].fileContent, 'true');
+});
+
+test('validateAiOutput rejects duplicate target paths', () => {
+  assert.throws(
+    () => validateAiOutput({
+      summary: 'ok',
+      changes: [
+        { target_path: 'a.md', file_content: '1' },
+        { target_path: 'a.md', file_content: '2' },
+      ],
+    }),
+    /duplicate target_path/,
+  );
 });

--- a/scripts/tests/prompts.test.mjs
+++ b/scripts/tests/prompts.test.mjs
@@ -92,6 +92,7 @@ describe('prompt file contents', () => {
   test('generation-system mentions the three required JSON output keys', () => {
     const content = loadPrompt('generation-system');
     assert.ok(content.includes('summary'));
+    assert.ok(content.includes('changes'));
     assert.ok(content.includes('target_path'));
     assert.ok(content.includes('file_content'));
   });
@@ -106,6 +107,7 @@ describe('prompt file contents', () => {
   test('generation-user contains the JSON output schema', () => {
     const content = loadPrompt('generation-user');
     assert.ok(content.includes('summary'));
+    assert.ok(content.includes('changes'));
     assert.ok(content.includes('target_path'));
     assert.ok(content.includes('file_content'));
   });


### PR DESCRIPTION
### Motivation
- Prevent the AI generation workflow from running on unvalidated issues by requiring the `ready-for-dev` label before `ai-task` can trigger a run.
- Change the generation prompt and runtime so the model can propose a small multi-file patch instead of a single file, matching the desire to avoid one-file-only outputs.

### Description
- Gate the `.github/workflows/ai-issue-to-pr.yml` job to require the applied label to be `ai-task` and that the issue already contains `ready-for-dev`, and switch PR `add-paths` to consume `generated_paths`.
- Update prompts `prompts/generation-system.md` and `prompts/generation-user.md` to request a `changes` array (1–3 files) in the JSON output schema instead of a single `target_path`/`file_content` pair.
- Modify `scripts/generate_issue_change.mjs` to parse/validate `changes`, write multiple files, and export `generated_paths` to `GITHUB_OUTPUT` for the PR action.
- Replace `scripts/lib/output_writer.mjs` logic to validate 1–3 changes, reject duplicate paths, enforce per-file size and path safety, and write all validated files returning their paths.
- Update unit tests under `scripts/tests/` to reflect the new `changes` schema and add tests exercising multi-file validation and duplicate/path error cases.
- Update `docs/ai-issue-to-pr.md` to document the label gating and the new maximum-3-file behavior.

### Testing
- Ran the test suite with `npm test` and all tests passed (test run completed successfully).
- The updated prompt/load and output validation tests were included and succeeded during the `npm test` run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81fbf89d08325bc0f79449af9545f)