### PR TITLE
Upsert Issue Validation Report comment instead of creating duplicates

### DIFF
--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -32,15 +32,13 @@ jobs:
           GROQ_API_URL: ${{ vars.GROQ_API_URL }}
         run: node scripts/validate_issue.mjs
 
-      - name: Post validation comment
+      - name: Upsert validation comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           COMMENT_BODY: ${{ steps.validate.outputs.comment }}
-        run: |
-          printf '%s' "$COMMENT_BODY" > /tmp/validation_comment.md
-          gh issue comment ${{ github.event.issue.number }} \
-            --repo ${{ github.repository }} \
-            --body-file /tmp/validation_comment.md
+        run: node scripts/upsert_issue_validation_comment.mjs
 
       - name: Manage labels
         env:

--- a/scripts/upsert_issue_validation_comment.mjs
+++ b/scripts/upsert_issue_validation_comment.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import { requireEnv } from './lib/config.mjs';
+
+const COMMENT_MARKER = '<!-- issue-validation-report -->';
+
+function getHeaders(token) {
+  return {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+async function githubRequest({ method, path, token, body }) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: getHeaders(token),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (!response.ok) {
+    const payload = await response.text();
+    throw new Error(`GitHub API ${method} ${path} failed (${response.status}): ${payload}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  return response.json();
+}
+
+function buildCommentBody(comment) {
+  return comment.includes(COMMENT_MARKER) ? comment : `${COMMENT_MARKER}\n${comment}`;
+}
+
+async function main() {
+  const issueNumber = requireEnv('ISSUE_NUMBER');
+  const repo = requireEnv('GITHUB_REPOSITORY');
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const commentBody = requireEnv('COMMENT_BODY');
+
+  if (!token) {
+    throw new Error('Missing GH_TOKEN or GITHUB_TOKEN');
+  }
+
+  const [owner, name] = repo.split('/');
+  if (!owner || !name) {
+    throw new Error(`Invalid GITHUB_REPOSITORY format: ${repo}`);
+  }
+
+  const comments = await githubRequest({
+    method: 'GET',
+    path: `/repos/${owner}/${name}/issues/${issueNumber}/comments?per_page=100`,
+    token,
+  });
+
+  const existing = comments.find((comment) => String(comment.body || '').includes(COMMENT_MARKER));
+  const body = buildCommentBody(commentBody);
+
+  if (existing) {
+    await githubRequest({
+      method: 'PATCH',
+      path: `/repos/${owner}/${name}/issues/comments/${existing.id}`,
+      token,
+      body: { body },
+    });
+    console.log(`[INFO] Updated validation comment ${existing.id} on issue #${issueNumber}`);
+    return;
+  }
+
+  await githubRequest({
+    method: 'POST',
+    path: `/repos/${owner}/${name}/issues/${issueNumber}/comments`,
+    token,
+    body: { body },
+  });
+  console.log(`[INFO] Created validation comment on issue #${issueNumber}`);
+}
+
+main().catch((error) => {
+  console.error(`[ERROR] ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- The validation workflow currently creates a new comment each run which clutters issues, so the agent should reuse a single comment instead. 
- Move comment management out of the workflow shell step and into a small Node.js helper to keep workflow orchestration minimal.
- Provide a stable marker so the script can reliably find and update the managed comment on subsequent validations.

### Description
- Replace the workflow step that posted a new comment with an upsert step that runs `node scripts/upsert_issue_validation_comment.mjs` and forwards `COMMENT_BODY`, `ISSUE_NUMBER`, and `GITHUB_REPOSITORY` as env vars. 
- Add `scripts/upsert_issue_validation_comment.mjs`, a Node.js script that tags the managed comment with `<!-- issue-validation-report -->`, lists issue comments, `PATCH`es the existing marked comment if found, and `POST`s a new comment otherwise. 
- The script validates required environment variables and uses the GitHub REST API with proper headers to perform `GET`/`PATCH`/`POST` calls while surfacing API errors.

### Testing
- Ran `npm test` locally and all automated tests passed successfully. 
- Test summary: `node --test scripts/tests/*.test.mjs` completed with 115 tests and 0 failures. 
- No existing unit tests were modified and the new script is structured for testability and minimal surface area in the workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e829e5184883259c492b01aebc8338)