### PR TITLE
fix: déclencher ai-issue-to-pr automatiquement depuis la validation

### DIFF
--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
+  actions: write
 
 jobs:
   validate:


### PR DESCRIPTION
## Problème

Quand `validate-issue.yml` ajoutait le label `ready-for-dev` via `GITHUB_TOKEN`, le workflow `ai-issue-to-pr.yml` ne se déclenchait pas — GitHub bloque intentionnellement les cascades d'événements venant du `GITHUB_TOKEN`.

## Solution

**`validate-issue.yml`**
- Appelle directement `gh workflow run ai-issue-to-pr.yml` après validation réussie (contourne la limite `GITHUB_TOKEN`)
- Ajoute la permission `actions: write` requise pour déclencher un workflow

**`ai-issue-to-pr.yml`**
- Ajoute un trigger `workflow_dispatch` avec `issue_number` en input
- Ajoute un step "Resolve issue data" qui récupère title/body depuis l'API GitHub (fonctionne dans les deux modes : label manuel ou dispatch automatique)

## Flux après merge

```
Issue créée/éditée
  → validate-issue.yml
    → ajoute ready-for-dev
    → gh workflow run ai-issue-to-pr.yml  ← nouveau
      → génère la PR automatiquement
```

Le déclenchement manuel (ajouter `ready-for-dev` à la main) continue aussi de fonctionner.

## Test plan

- [ ] Créer une issue bien rédigée → vérifier que `ready-for-dev` est apposé ET qu'une PR est créée automatiquement
- [ ] Créer une issue mal rédigée → vérifier que seul `needs-refinement` est apposé, pas de PR
- [ ] Ajouter `ready-for-dev` manuellement sur une issue → vérifier que la PR est créée

https://claude.ai/code/session_01H9g4Dnkp8DCbfwZsYR17Bb