### PR TITLE
fix: raise file output cap from 3 to 6 across code, prompts, tests and docs

### DIFF
--- a/docs/adr/0003-safe-output-scope.md
+++ b/docs/adr/0003-safe-output-scope.md
@@ -1,4 +1,4 @@
-# ADR-0003: Safe output scope (up to 3 generated files)
+# ADR-0003: Safe output scope (up to 6 generated files)
 
 - **Date:** 2026-04-14
 - **Status:** Accepted
@@ -7,12 +7,12 @@
 
 MVP requires low-risk automated code changes and clear failure behavior.
 Single-file output proved too restrictive for tasks that naturally span a source file
-and its test, so the scope was relaxed to a hard cap of 3 files while keeping the
+and its test, so the scope was relaxed to a hard cap of 6 files while keeping the
 same safety invariants.
 
 ## Decision
 
-Constrain generation to a maximum of 3 validated relative file paths returned by the AI:
+Constrain generation to a maximum of 6 validated relative file paths returned by the AI:
 - no absolute paths
 - no `..` traversal
 - duplicate target paths within a single run are rejected
@@ -26,4 +26,4 @@ file write steps fail.
 - ✅ Minimizes blast radius of generated changes.
 - ✅ Keeps review surface small and easy to audit.
 - ✅ Allows source + test (+ optional config) in a single run.
-- ⚠️ Tasks requiring more than 3 files remain out of scope for MVP.
+- ⚠️ Tasks requiring more than 6 files remain out of scope for MVP.

--- a/docs/ai-issue-to-pr.md
+++ b/docs/ai-issue-to-pr.md
@@ -15,7 +15,7 @@ Node implementation:
 When the `ready-for-dev` label is applied to an issue, the workflow:
 1. Builds a deterministic prompt using issue number, title, and body.
 2. Calls the Groq API using repository secrets.
-3. Writes 1 to 3 generated files at AI-selected relative paths.
+3. Writes 1 to 6 generated files at AI-selected relative paths.
 4. Creates a branch named `ai/issue-<number>`.
 5. Uses `peter-evans/create-pull-request` to commit generated content on `ai/issue-<number>`.
 6. Opens a PR to the repository default branch with `Closes #<issue_number>`.
@@ -66,12 +66,12 @@ The validation workflow creates and manages these labels automatically:
 6. Confirm PR details:
    - title references the issue number/title
    - body includes generated summary and `Closes #<number>`
-   - changed files are limited to the generated AI target paths (maximum 3 files)
+   - changed files are limited to the generated AI target paths (maximum 6 files)
 
 ## Limitations (MVP)
 
 - Triggers on `ready-for-dev` label application event.
-- Applies 1 to 3 small generated files per run (safe scope).
+- Applies 1 to 6 generated files per run (safe scope).
 - Does not perform auto-merge.
 - Does not attempt multi-file or complex refactors.
 
@@ -80,7 +80,7 @@ The validation workflow creates and manages these labels automatically:
 - **Risk:** AI output may be low quality or off-target.
   - **Mitigation:** deterministic prompt template, temperature `0`, and small-scope generated file.
 - **Risk:** accidental broad modifications.
-  - **Mitigation:** generated patch is constrained to validated relative paths with a hard limit of 3 files per run.
+  - **Mitigation:** generated patch is constrained to validated relative paths with a hard limit of 6 files per run.
 - **Risk:** workflow secrets misconfiguration.
   - **Mitigation:** explicit secret checks and fail-fast logging before commit/PR steps.
 

--- a/docs/mvp.md
+++ b/docs/mvp.md
@@ -19,12 +19,12 @@ Teams lose time on repetitive starter tasks (small fixes, doc updates, scaffoldi
 - Trigger PR generation on **issue labeled** event, gated to the `ready-for-dev` label.
 - Build a prompt from issue title + body.
 - Call an AI model with that prompt.
-- Create/modify up to 3 files in a dedicated branch.
+- Create/modify up to 6 files in a dedicated branch.
 - Open a PR with generated title/body.
 - Add basic logging for traceability.
 
 ## Out of Scope (MVP)
-- Multi-file complex refactors (hard cap: 3 files per run).
+- Multi-file complex refactors (hard cap: 6 files per run).
 - Full autonomous code review.
 - Automatic merge.
 - Advanced security policy engine.
@@ -34,7 +34,7 @@ Teams lose time on repetitive starter tasks (small fixes, doc updates, scaffoldi
 1. On `issues.opened` or `issues.edited`, the validation workflow runs and applies either `ready-for-dev` or `needs-refinement`.
 2. On `issues.labeled`, the generation workflow runs only when the applied label is `ready-for-dev`.
 3. Workflow sends deterministic prompt template to AI.
-4. AI output is applied as a minimal patch (1–3 files, safe relative paths only).
+4. AI output is applied as a minimal patch (1–6 files, safe relative paths only).
 5. Branch naming follows convention (e.g., `ai/issue-<number>`).
 6. PR is created against default branch.
 7. PR links back to the original issue.
@@ -60,5 +60,5 @@ Teams lose time on repetitive starter tasks (small fixes, doc updates, scaffoldi
 
 ## Next Steps
 - Improve issue validation guidance and reviewer feedback loops for low-scoring tasks.
-- Add additional safety policies while preserving the 3-file MVP scope.
+- Add additional safety policies while preserving the 6-file MVP scope.
 - Pilot with larger issue samples and track quality metrics against acceptance criteria.

--- a/scripts/lib/output_writer.mjs
+++ b/scripts/lib/output_writer.mjs
@@ -39,7 +39,7 @@ export function validateAiOutput(aiOutput) {
     throw new Error('AI response missing non-empty changes array');
   }
   if (changes.length > MAX_FILE_COUNT) {
-    throw new Error('AI response changes array too large (>3 files)');
+    throw new Error('AI response changes array too large (>6 files)');
   }
 
   const normalizedChanges = changes.map((change, index) => validateSingleChange(change, index));


### PR DESCRIPTION
## Summary

- Raises `MAX_FILE_COUNT` in `output_writer.mjs` from 3 to 6 so the validator accepts tasks that naturally span more files (e.g. a React app with `package.json`, `index.html`, bundler config, `src/` files)
- Updates the generation system and user prompts to reflect the new hard limit and removes over-prescriptive consolidation guidance
- Updates the failing test to assert the new boundary (7 files → error, 6 files → ok)
- Propagates the change to all remaining references: error message string, `docs/mvp.md`, `docs/ai-issue-to-pr.md`, and `docs/adr/0003-safe-output-scope.md`

## Test plan

- [x] `npm test` passes (127/127) on this branch
- [x] No stale `3-file` / `>3` references remain in code, prompts or docs

Closes #32

https://claude.ai/code/session_01CPWFKdggjrmn6mqfWifkLY