### PR TITLE
test: cover writeGeneratedFiles and pr_review business logic

### DIFF
--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -25,6 +25,8 @@ if (!prNumber) throw new Error('Missing pull_request.number in event payload');
 
 const [owner, repo] = repository.split('/');
 
+const githubApiBase = (process.env.GITHUB_API_URL || 'https://api.github.com').trim();
+
 const githubHeaders = {
   Authorization: `Bearer ${githubToken}`,
   'Content-Type': 'application/json',
@@ -33,7 +35,7 @@ const githubHeaders = {
 
 async function ghFetch(path, options = {}) {
   try {
-    return await fetch(`https://api.github.com${path}`, {
+    return await fetch(`${githubApiBase}${path}`, {
       ...options,
       headers: { ...githubHeaders, ...(options.headers || {}) },
     });

--- a/scripts/tests/output_writer.test.mjs
+++ b/scripts/tests/output_writer.test.mjs
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { validateAiOutput } from '../lib/output_writer.mjs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { validateAiOutput, writeGeneratedFiles } from '../lib/output_writer.mjs';
 
 test('validateAiOutput returns trimmed fields for valid input', () => {
   const result = validateAiOutput({
@@ -115,4 +118,90 @@ test('validateAiOutput rejects duplicate target paths', () => {
     }),
     /duplicate target_path/,
   );
+});
+
+// writeGeneratedFiles tests
+
+test('writeGeneratedFiles returns empty array for empty input', async () => {
+  const paths = await writeGeneratedFiles([]);
+  assert.deepEqual(paths, []);
+});
+
+test('writeGeneratedFiles writes a single flat file and returns its path', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ow-test-'));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(tmpDir);
+    const paths = await writeGeneratedFiles([{ targetPath: 'output.txt', fileContent: 'hello world' }]);
+    assert.deepEqual(paths, ['output.txt']);
+    const content = await fs.readFile(path.join(tmpDir, 'output.txt'), 'utf8');
+    assert.equal(content, 'hello world');
+  } finally {
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+test('writeGeneratedFiles creates nested parent directories', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ow-test-'));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(tmpDir);
+    const paths = await writeGeneratedFiles([{ targetPath: 'src/lib/utils.js', fileContent: 'export {}' }]);
+    assert.deepEqual(paths, ['src/lib/utils.js']);
+    const content = await fs.readFile(path.join(tmpDir, 'src/lib/utils.js'), 'utf8');
+    assert.equal(content, 'export {}');
+  } finally {
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+test('writeGeneratedFiles writes correct content for each file in a batch', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ow-test-'));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(tmpDir);
+    await writeGeneratedFiles([
+      { targetPath: 'alpha.txt', fileContent: 'alpha content' },
+      { targetPath: 'beta.txt', fileContent: 'beta content' },
+    ]);
+    assert.equal(await fs.readFile(path.join(tmpDir, 'alpha.txt'), 'utf8'), 'alpha content');
+    assert.equal(await fs.readFile(path.join(tmpDir, 'beta.txt'), 'utf8'), 'beta content');
+  } finally {
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+test('writeGeneratedFiles returns all written paths in order', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ow-test-'));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(tmpDir);
+    const paths = await writeGeneratedFiles([
+      { targetPath: 'a.txt', fileContent: 'a' },
+      { targetPath: 'b.txt', fileContent: 'b' },
+      { targetPath: 'sub/c.txt', fileContent: 'c' },
+    ]);
+    assert.deepEqual(paths, ['a.txt', 'b.txt', 'sub/c.txt']);
+  } finally {
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+test('writeGeneratedFiles overwrites an existing file', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ow-test-'));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(tmpDir);
+    await fs.writeFile(path.join(tmpDir, 'existing.txt'), 'old content');
+    await writeGeneratedFiles([{ targetPath: 'existing.txt', fileContent: 'new content' }]);
+    const content = await fs.readFile(path.join(tmpDir, 'existing.txt'), 'utf8');
+    assert.equal(content, 'new content');
+  } finally {
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
 });

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -1,0 +1,209 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import http from 'node:http';
+
+const SCRIPTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const HEADING = '## 🔍 Automated Code Review';
+const PR_NUMBER = 42;
+const COMMENT_ID = 999;
+const SAMPLE_DIFF = '--- a/foo.js\n+++ b/foo.js\n@@ -1 +1 @@\n+added line\n';
+
+function startMockServer(handler) {
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    let rawBody = '';
+    req.on('data', (d) => (rawBody += d));
+    req.on('end', () => {
+      requests.push({ method: req.method, url: req.url, body: rawBody });
+      handler(req, res);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      server.requests = requests;
+      resolve(server);
+    });
+  });
+}
+
+function groqJson(content) {
+  return JSON.stringify({ choices: [{ message: { content } }] });
+}
+
+function makeHandler({
+  diffStatus = 200,
+  groqContent = 'Review text here.',
+  commentsStatus = 200,
+  commentsBody = '[]',
+  upsertStatus = 201,
+} = {}) {
+  return (req, res) => {
+    const { method, url } = req;
+
+    if (url === '/v1/chat/completions') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(groqJson(groqContent));
+    }
+
+    if (method === 'GET' && /\/pulls\/\d+$/.test(url)) {
+      res.writeHead(diffStatus);
+      return res.end(diffStatus < 300 ? SAMPLE_DIFF : 'Forbidden');
+    }
+
+    if (method === 'GET' && url.includes('/issues/') && url.includes('/comments')) {
+      res.writeHead(commentsStatus, { 'Content-Type': 'application/json' });
+      return res.end(commentsStatus < 300 ? commentsBody : 'Internal Server Error');
+    }
+
+    if ((method === 'POST' || method === 'PATCH') && url.includes('/comments')) {
+      res.writeHead(upsertStatus, { 'Content-Type': 'application/json' });
+      return res.end(upsertStatus < 300 ? '{"id":1}' : 'Internal Server Error');
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  };
+}
+
+async function runPrReview(port, eventFile, extraEnv = {}) {
+  const env = {
+    PATH: process.env.PATH,
+    GITHUB_TOKEN: 'test-token',
+    GROQ_API_KEY: 'test-key',
+    GITHUB_REPOSITORY: 'owner/repo',
+    GITHUB_EVENT_PATH: eventFile,
+    GITHUB_API_URL: `http://127.0.0.1:${port}`,
+    GROQ_API_URL: `http://127.0.0.1:${port}/v1/chat/completions`,
+    ...extraEnv,
+  };
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [path.join(SCRIPTS_DIR, 'pr_review.mjs')], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d));
+    child.stderr.on('data', (d) => (stderr += d));
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+async function writeEventFile(prNumber = PR_NUMBER) {
+  const tmpFile = path.join(os.tmpdir(), `pr-review-biz-${Date.now()}-${Math.random()}.json`);
+  await fs.writeFile(tmpFile, JSON.stringify({ pull_request: { number: prNumber } }));
+  return tmpFile;
+}
+
+test('pr_review exits 1 when diff fetch returns non-2xx', async () => {
+  const server = await startMockServer(makeHandler({ diffStatus: 403 }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /Diff fetch failed/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review exits 1 when comment list fetch returns non-2xx', async () => {
+  const server = await startMockServer(makeHandler({ commentsStatus: 500 }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /Comment list failed/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review exits 1 when comment upsert returns non-2xx', async () => {
+  const server = await startMockServer(makeHandler({ upsertStatus: 500 }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /Comment upsert failed/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review POSTs new comment when no existing comment found', async () => {
+  const server = await startMockServer(makeHandler({ commentsBody: '[]', upsertStatus: 201 }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const upsert = server.requests.find((r) => r.method === 'POST' && r.url.includes('/comments'));
+    assert.ok(upsert, 'expected a POST to the comments endpoint');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review PATCHes existing comment when one already contains the heading', async () => {
+  const existingComment = [{ id: COMMENT_ID, body: `${HEADING}\n\nprevious review` }];
+  const server = await startMockServer(
+    makeHandler({ commentsBody: JSON.stringify(existingComment), upsertStatus: 200 }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const patch = server.requests.find((r) => r.method === 'PATCH');
+    assert.ok(patch, 'expected a PATCH request');
+    assert.ok(
+      patch.url.endsWith(`/issues/comments/${COMMENT_ID}`),
+      `expected PATCH to /issues/comments/${COMMENT_ID}, got: ${patch.url}`,
+    );
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review prepends heading when Groq response does not include it', async () => {
+  const server = await startMockServer(makeHandler({ groqContent: 'Plain review text.' }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const upsert = server.requests.find((r) => (r.method === 'POST' || r.method === 'PATCH') && r.url.includes('/comments'));
+    assert.ok(upsert, 'expected a comment upsert request');
+    const { body } = JSON.parse(upsert.body);
+    assert.ok(body.startsWith(HEADING), `expected body to start with heading, got: ${body.slice(0, 80)}`);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review does not duplicate heading when Groq response already contains it', async () => {
+  const groqContent = `${HEADING}\n\nDetailed review.`;
+  const server = await startMockServer(makeHandler({ groqContent }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const upsert = server.requests.find((r) => (r.method === 'POST' || r.method === 'PATCH') && r.url.includes('/comments'));
+    assert.ok(upsert, 'expected a comment upsert request');
+    const { body } = JSON.parse(upsert.body);
+    const occurrences = body.split(HEADING).length - 1;
+    assert.equal(occurrences, 1, `heading should appear exactly once, found ${occurrences} times`);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});


### PR DESCRIPTION
- Add GITHUB_API_URL env var to pr_review.mjs (mirrors GROQ_API_URL) so
  the GitHub API base URL can be pointed at a local mock server in tests
- Add 6 tests for writeGeneratedFiles (flat write, nested dirs, batch
  paths, content per file, overwrite, empty input)
- Add pr_review.test.mjs with 7 tests using an in-process HTTP mock
  server: diff 4xx, comment list 5xx, upsert 5xx, POST on new comment,
  PATCH on existing comment, heading prepended when missing, heading not
  duplicated when already present

https://claude.ai/code/session_01VBZwhdGSeXWyUgNvewEdRC