### PR TITLE
feat: add labels to PR code review (review-approved / changes-requested)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
+  issues: write
 
 jobs:
   review:

--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -1,0 +1,22 @@
+# Label definitions for all automated pipeline stages.
+# Each label requires: name, color (hex without #), description.
+
+issue:
+  valid:
+    name: ready-for-dev
+    color: 0075ca
+    description: Issue validated and ready for automated implementation
+  invalid:
+    name: needs-refinement
+    color: e4e669
+    description: Issue requires clearer acceptance criteria before automation
+
+review:
+  approved:
+    name: review-approved
+    color: 0e8a16
+    description: Automated code review passed without requested changes
+  changes:
+    name: changes-requested
+    color: d93f0b
+    description: Automated code review found issues requiring changes

--- a/docs/ai-issue-to-pr.md
+++ b/docs/ai-issue-to-pr.md
@@ -64,6 +64,13 @@ The validation workflow creates and manages these labels automatically:
 - `ready-for-dev` — applied when issue quality is sufficient; triggers PR generation.
 - `needs-refinement` — applied when the issue requires clearer acceptance criteria.
 
+The PR review workflow creates and manages these labels automatically:
+
+- `review-approved` — applied when the automated code review verdict is APPROVED.
+- `changes-requested` — applied when the automated code review verdict is REQUEST_CHANGES.
+
+All label names, colors, and descriptions are configurable in `config/labels.yaml`.
+
 ## End-to-End Test
 
 1. Ensure secrets above are configured.
@@ -101,6 +108,14 @@ The validation workflow creates and manages these labels automatically:
 File: `.github/workflows/pr-review.yml`
 
 Required secret:
-- **Secret**: `ANTHROPIC_API_KEY` or `GROQ_API_KEY` — used to review pull request diffs and post/update a structured PR comment. Same provider selection rules apply (see above).
+- **Secret**: `ANTHROPIC_API_KEY` or `GROQ_API_KEY` — used to review pull request diffs. Same provider selection rules apply (see above).
 
-The workflow runs on pull requests (`opened`, `synchronize`, `reopened`) with `pull-requests: write` and `contents: read`.
+The workflow runs on pull requests (`opened`, `synchronize`, `reopened`) with permissions `pull-requests: write`, `contents: read`, and `issues: write`.
+
+On each run it:
+1. Fetches the PR diff and calls the LLM for a structured review.
+2. Posts or updates a comment on the PR with the full review text.
+3. Submits an official GitHub pull request review with event `APPROVE` or `REQUEST_CHANGES` based on the verdict in the LLM response.
+4. Applies the label `review-approved` or `changes-requested` to the PR (and removes the other).
+
+**Review submission permission:** submitting a GitHub review requires the repository setting **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** to be enabled. If it is not enabled, the review submission is skipped with a warning (the comment and labels are still applied). This is the same setting used for PR creation by the generation workflow.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,12 +15,15 @@ Requires Node.js 20+. All tests should pass in under a second.
 | File | Tests | What is covered |
 |------|-------|-----------------|
 | `scripts/lib/output_writer.mjs` | 10 | Field validation, path safety (absolute paths, `..` traversal), 16 000-char size limit, type coercion |
-| `scripts/lib/config.mjs` | 12 | `requireEnv` missing/empty vars, `loadConfigFromEnv` defaults and required fields, `buildDeterministicPrompt` output structure |
+| `scripts/lib/config.mjs` | 12 | `requireEnv` missing/empty vars, `loadConfigFromEnv` defaults and required fields, `buildDeterministicPrompt` output structure, `loadLabelsConfig` group resolution |
 | `scripts/lib/groq_client.mjs` | 7 | HTTP errors, non-JSON response, malformed `choices`, Authorization header, temperature payload |
 | `scripts/lib/anthropic_client.mjs` | 10 | HTTP errors, non-JSON response, malformed `content`, `x-api-key` header, `anthropic-version` header, temperature, `max_tokens`, system prompt placement |
 | `scripts/lib/llm_client.mjs` | 4 | Default routes to Anthropic, explicit `AI_PROVIDER=groq` routes to Groq, `AI_PROVIDER=anthropic` routes to Anthropic, case-insensitivity |
 | `scripts/lib/issue_validator.mjs` | 51 | `VALIDATION_SYSTEM_PROMPT` structure, `isMeaningfulTitle` edge cases, `buildValidationUserPrompt` edge cases, `parseGroqResponse` hard rules and error cases, `formatGitHubComment` formatting, `validateIssue` integration (including prefix-only title short-circuit) |
 | `scripts/lib/prompts.mjs` + `prompts/*.md` | 22 | `loadPrompt` for all 6 prompt files, `interpolatePrompt` placeholder substitution, per-file content assertions (keywords, placeholders, length) |
+| `scripts/lib/yaml.mjs` | 15 | `parseFlatYaml` key/value parsing, blank lines, comments, colons in values; `parseNestedYaml` 3-level nesting, multiple groups, `labels.yaml` structure |
+| `scripts/manage_labels.mjs` | 8 | Label upsert (create + PATCH fallback), apply/remove swap for `IS_VALID=true/false`, error cases (create 500, PATCH 500, add 422, remove 500), 404 on remove treated as success |
+| `scripts/pr_review.mjs` | 19 | Diff fetch errors, comment list/upsert errors, review submit errors (500 fatal, 422 warning), APPROVE/REQUEST_CHANGES event, heading-style verdict detection, label swap, PATCH fallback on label 422 |
 
 ## Prompt Files
 

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -2,11 +2,20 @@ import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { loadPrompt, interpolatePrompt } from './prompts.mjs';
-import { parseFlatYaml } from './yaml.mjs';
+import { parseFlatYaml, parseNestedYaml } from './yaml.mjs';
 
-const MODELS_FILE = resolve(dirname(fileURLToPath(import.meta.url)), '../../config/models.yaml');
+const CONFIG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '../../config');
+const MODELS_FILE = resolve(CONFIG_DIR, 'models.yaml');
+const LABELS_FILE = resolve(CONFIG_DIR, 'labels.yaml');
 
 export const GROQ_MODEL_DEFAULTS = parseFlatYaml(readFileSync(MODELS_FILE, 'utf8'));
+
+export function loadLabelsConfig(group) {
+  const all = parseNestedYaml(readFileSync(LABELS_FILE, 'utf8'));
+  const section = all[group];
+  if (!section) throw new Error(`Unknown label group "${group}" in labels.yaml`);
+  return section;
+}
 
 export const GROQ_API_URL_DEFAULT = 'https://api.groq.com/openai/v1/chat/completions';
 

--- a/scripts/lib/yaml.mjs
+++ b/scripts/lib/yaml.mjs
@@ -15,3 +15,35 @@ export function parseFlatYaml(content) {
   }
   return result;
 }
+
+/**
+ * Minimal parser for 3-level nested YAML (top-key → section-key → leaf key: value).
+ * Supports blank lines and # comments. No anchors, no lists, no inline objects.
+ * Indentation must be consistent: 2 spaces per level.
+ */
+export function parseNestedYaml(content) {
+  const result = {};
+  let l0 = null;
+  let l1 = null;
+  for (const raw of content.split('\n')) {
+    const line = raw.replace(/\r$/, '');
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const indent = line.length - trimmed.length;
+    const colon = trimmed.indexOf(':');
+    if (colon === -1) continue;
+    const key = trimmed.slice(0, colon).trim();
+    const value = trimmed.slice(colon + 1).trim();
+    if (indent === 0) {
+      l0 = key;
+      result[l0] = {};
+      l1 = null;
+    } else if (indent === 2) {
+      l1 = key;
+      if (l0) result[l0][l1] = {};
+    } else if (indent === 4 && l0 && l1) {
+      result[l0][l1][key] = value;
+    }
+  }
+  return result;
+}

--- a/scripts/manage_labels.mjs
+++ b/scripts/manage_labels.mjs
@@ -1,20 +1,10 @@
 #!/usr/bin/env node
 
-import { requireEnv } from './lib/config.mjs';
+import { requireEnv, loadLabelsConfig } from './lib/config.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 
-const LABELS = [
-  {
-    name: 'ready-for-dev',
-    color: '0075ca',
-    description: 'Issue validated and ready for automated implementation',
-  },
-  {
-    name: 'needs-refinement',
-    color: 'e4e669',
-    description: 'Issue requires clearer acceptance criteria before automation',
-  },
-];
+const issueLabels = loadLabelsConfig('issue');
+const LABELS = [issueLabels.valid, issueLabels.invalid];
 
 function getHeaders(token) {
   return {
@@ -89,8 +79,8 @@ async function main() {
     log('Label upserted', { label: label.name });
   }
 
-  const apply = isValid ? 'ready-for-dev' : 'needs-refinement';
-  const remove = isValid ? 'needs-refinement' : 'ready-for-dev';
+  const apply = isValid ? issueLabels.valid.name : issueLabels.invalid.name;
+  const remove = isValid ? issueLabels.invalid.name : issueLabels.valid.name;
 
   await addLabel(owner, name, token, issueNumber, apply);
   await removeLabel(owner, name, token, issueNumber, remove);

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -127,7 +127,7 @@ if (!postRes.ok) throw new Error(`Comment upsert failed: ${postRes.status} ${awa
 
 log(`PR review ${existing ? 'updated' : 'posted'}`, { prNumber });
 
-const verdictMatch = rawReview.match(/Verdict:\s*(APPROVED|REQUEST_CHANGES)/i);
+const verdictMatch = rawReview.match(/verdict(?::\s*|\s*\n+\s*)(APPROVED|REQUEST_CHANGES)/i);
 const isApproved = verdictMatch?.[1]?.toUpperCase() === 'APPROVED';
 
 for (const label of PR_REVIEW_LABELS) {

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -33,6 +33,19 @@ const githubHeaders = {
   'X-GitHub-Api-Version': '2022-11-28',
 };
 
+const PR_REVIEW_LABELS = [
+  {
+    name: 'review-approved',
+    color: '0e8a16',
+    description: 'Automated code review passed without requested changes',
+  },
+  {
+    name: 'changes-requested',
+    color: 'd93f0b',
+    description: 'Automated code review found issues requiring changes',
+  },
+];
+
 async function ghFetch(path, options = {}) {
   try {
     return await fetch(`${githubApiBase}${path}`, {
@@ -41,6 +54,42 @@ async function ghFetch(path, options = {}) {
     });
   } catch (err) {
     throw new Error(`Network error calling GitHub API (${path}): ${err.message}`);
+  }
+}
+
+async function upsertLabel(label) {
+  const createRes = await ghFetch(`/repos/${owner}/${repo}/labels`, {
+    method: 'POST',
+    body: JSON.stringify(label),
+  });
+  if (createRes.status === 201) return;
+  if (createRes.status !== 422) {
+    throw new Error(`Label create failed for "${label.name}": ${createRes.status}`);
+  }
+  const updateRes = await ghFetch(
+    `/repos/${owner}/${repo}/labels/${encodeURIComponent(label.name)}`,
+    { method: 'PATCH', body: JSON.stringify(label) },
+  );
+  if (!updateRes.ok) {
+    throw new Error(`Label update failed for "${label.name}": ${updateRes.status}`);
+  }
+}
+
+async function addLabel(labelName) {
+  const res = await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/labels`, {
+    method: 'POST',
+    body: JSON.stringify({ labels: [labelName] }),
+  });
+  if (!res.ok) throw new Error(`Add label "${labelName}" failed: ${res.status}`);
+}
+
+async function removeLabel(labelName) {
+  const res = await ghFetch(
+    `/repos/${owner}/${repo}/issues/${prNumber}/labels/${encodeURIComponent(labelName)}`,
+    { method: 'DELETE' },
+  );
+  if (!res.ok && res.status !== 404) {
+    throw new Error(`Remove label "${labelName}" failed: ${res.status}`);
   }
 }
 
@@ -87,3 +136,18 @@ const postRes = await ghFetch(commentUrl, {
 if (!postRes.ok) throw new Error(`Comment upsert failed: ${postRes.status} ${await postRes.text()}`);
 
 log(`PR review ${existing ? 'updated' : 'posted'}`, { prNumber });
+
+const verdictMatch = rawReview.match(/Verdict:\s*(APPROVED|REQUEST_CHANGES)/i);
+const isApproved = verdictMatch?.[1]?.toUpperCase() === 'APPROVED';
+
+for (const label of PR_REVIEW_LABELS) {
+  await upsertLabel(label);
+  log('Label upserted', { label: label.name });
+}
+
+const apply = isApproved ? 'review-approved' : 'changes-requested';
+const remove = isApproved ? 'changes-requested' : 'review-approved';
+
+await addLabel(apply);
+await removeLabel(remove);
+log('PR review labels applied', { prNumber, added: apply, removed: remove });

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -108,6 +108,9 @@ const HEADING = '## 🔍 Automated Code Review';
 const review = rawReview.trim();
 const body = review.includes(HEADING) ? review : `${HEADING}\n\n${review}`;
 
+const verdictMatch = rawReview.match(/verdict(?::\s*|\s*\n+\s*)(APPROVED|REQUEST_CHANGES)/i);
+const isApproved = verdictMatch?.[1]?.toUpperCase() === 'APPROVED';
+
 const commentsRes = await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`);
 if (!commentsRes.ok) throw new Error(`Comment list failed: ${commentsRes.status}`);
 
@@ -125,10 +128,18 @@ const postRes = await ghFetch(commentUrl, {
 });
 if (!postRes.ok) throw new Error(`Comment upsert failed: ${postRes.status} ${await postRes.text()}`);
 
-log(`PR review ${existing ? 'updated' : 'posted'}`, { prNumber });
+log(`PR review comment ${existing ? 'updated' : 'posted'}`, { prNumber });
 
-const verdictMatch = rawReview.match(/verdict(?::\s*|\s*\n+\s*)(APPROVED|REQUEST_CHANGES)/i);
-const isApproved = verdictMatch?.[1]?.toUpperCase() === 'APPROVED';
+const reviewRes = await ghFetch(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
+  method: 'POST',
+  body: JSON.stringify({
+    body,
+    event: isApproved ? 'APPROVE' : 'REQUEST_CHANGES',
+  }),
+});
+if (!reviewRes.ok) throw new Error(`Review submit failed: ${reviewRes.status} ${await reviewRes.text()}`);
+
+log('PR review submitted', { prNumber, event: isApproved ? 'APPROVE' : 'REQUEST_CHANGES' });
 
 for (const label of PR_REVIEW_LABELS) {
   await upsertLabel(label);

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
-import { requireEnv, loadLLMConfig } from './lib/config.mjs';
+import { requireEnv, loadLLMConfig, loadLabelsConfig } from './lib/config.mjs';
 import { callLLM } from './lib/llm_client.mjs';
 import { filterDiff } from './lib/file_filters.mjs';
 import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
@@ -33,18 +33,8 @@ const githubHeaders = {
   'X-GitHub-Api-Version': '2022-11-28',
 };
 
-const PR_REVIEW_LABELS = [
-  {
-    name: 'review-approved',
-    color: '0e8a16',
-    description: 'Automated code review passed without requested changes',
-  },
-  {
-    name: 'changes-requested',
-    color: 'd93f0b',
-    description: 'Automated code review found issues requiring changes',
-  },
-];
+const reviewLabels = loadLabelsConfig('review');
+const PR_REVIEW_LABELS = [reviewLabels.approved, reviewLabels.changes];
 
 async function ghFetch(path, options = {}) {
   try {
@@ -145,8 +135,8 @@ for (const label of PR_REVIEW_LABELS) {
   log('Label upserted', { label: label.name });
 }
 
-const apply = isApproved ? 'review-approved' : 'changes-requested';
-const remove = isApproved ? 'changes-requested' : 'review-approved';
+const apply = isApproved ? reviewLabels.approved.name : reviewLabels.changes.name;
+const remove = isApproved ? reviewLabels.changes.name : reviewLabels.approved.name;
 
 await addLabel(apply);
 await removeLabel(remove);

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -5,7 +5,7 @@ import { requireEnv, loadLLMConfig, loadLabelsConfig } from './lib/config.mjs';
 import { callLLM } from './lib/llm_client.mjs';
 import { filterDiff } from './lib/file_filters.mjs';
 import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
-import { log } from './lib/logger.mjs';
+import { log, error as logError } from './lib/logger.mjs';
 
 const githubToken = requireEnv('GITHUB_TOKEN');
 const repository = requireEnv('GITHUB_REPOSITORY');
@@ -137,9 +137,16 @@ const reviewRes = await ghFetch(`/repos/${owner}/${repo}/pulls/${prNumber}/revie
     event: isApproved ? 'APPROVE' : 'REQUEST_CHANGES',
   }),
 });
-if (!reviewRes.ok) throw new Error(`Review submit failed: ${reviewRes.status} ${await reviewRes.text()}`);
-
-log('PR review submitted', { prNumber, event: isApproved ? 'APPROVE' : 'REQUEST_CHANGES' });
+if (!reviewRes.ok) {
+  const detail = await reviewRes.text();
+  if (reviewRes.status === 422) {
+    logError('PR review submit skipped: GitHub Actions lacks permission to submit reviews. Enable "Allow GitHub Actions to create and approve pull requests" in repository Settings → Actions → General.', { prNumber, status: 422 });
+  } else {
+    throw new Error(`Review submit failed: ${reviewRes.status} ${detail}`);
+  }
+} else {
+  log('PR review submitted', { prNumber, event: isApproved ? 'APPROVE' : 'REQUEST_CHANGES' });
+}
 
 for (const label of PR_REVIEW_LABELS) {
   await upsertLabel(label);

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -202,13 +202,26 @@ test('pr_review PATCHes existing comment when one already contains the heading',
   }
 });
 
-test('pr_review exits 1 when review submit returns non-2xx', async () => {
+test('pr_review exits 1 when review submit returns non-2xx (not 422)', async () => {
   const server = await startMockServer(makeHandler({ reviewStatus: 500 }));
   const eventFile = await writeEventFile();
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.notEqual(result.code, 0);
     assert.match(result.stderr + result.stdout, /Review submit failed/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review logs warning and exits 0 when review submit returns 422 (permissions)', async () => {
+  const server = await startMockServer(makeHandler({ reviewStatus: 422 }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    assert.match(result.stderr + result.stdout, /lacks permission/);
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -41,6 +41,7 @@ function makeHandler({
   commentsStatus = 200,
   commentsBody = '[]',
   upsertStatus = 201,
+  reviewStatus = 201,
   labelCreateStatus = 201,
   labelUpdateStatus = 200,
   applyLabelStatus = 200,
@@ -67,6 +68,11 @@ function makeHandler({
     if ((method === 'POST' || method === 'PATCH') && url.includes('/comments')) {
       res.writeHead(upsertStatus, { 'Content-Type': 'application/json' });
       return res.end(upsertStatus < 300 ? '{"id":1}' : 'Internal Server Error');
+    }
+
+    if (method === 'POST' && /\/pulls\/\d+\/reviews$/.test(url)) {
+      res.writeHead(reviewStatus, { 'Content-Type': 'application/json' });
+      return res.end(reviewStatus < 300 ? '{"id":1}' : 'Internal Server Error');
     }
 
     if (method === 'POST' && /\/repos\/[^/]+\/[^/]+\/labels$/.test(url)) {
@@ -169,8 +175,8 @@ test('pr_review POSTs new comment when no existing comment found', async () => {
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    const upsert = server.requests.find((r) => r.method === 'POST' && r.url.includes('/comments'));
-    assert.ok(upsert, 'expected a POST to the comments endpoint');
+    const post = server.requests.find((r) => r.method === 'POST' && r.url.includes('/comments'));
+    assert.ok(post, 'expected a POST to the comments endpoint');
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});
@@ -186,12 +192,112 @@ test('pr_review PATCHes existing comment when one already contains the heading',
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    const patch = server.requests.find((r) => r.method === 'PATCH');
-    assert.ok(patch, 'expected a PATCH request');
-    assert.ok(
-      patch.url.endsWith(`/issues/comments/${COMMENT_ID}`),
-      `expected PATCH to /issues/comments/${COMMENT_ID}, got: ${patch.url}`,
+    const patch = server.requests.find(
+      (r) => r.method === 'PATCH' && r.url.endsWith(`/issues/comments/${COMMENT_ID}`),
     );
+    assert.ok(patch, `expected PATCH to /issues/comments/${COMMENT_ID}`);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review exits 1 when review submit returns non-2xx', async () => {
+  const server = await startMockServer(makeHandler({ reviewStatus: 500 }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /Review submit failed/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review submits review to pulls reviews endpoint', async () => {
+  const server = await startMockServer(makeHandler());
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected a POST to /pulls/{n}/reviews');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review submits APPROVE event when verdict is APPROVED', async () => {
+  const server = await startMockServer(makeHandler({ groqContent: 'All good.\n\nVerdict: APPROVED' }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.equal(JSON.parse(review.body).event, 'APPROVE');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review submits REQUEST_CHANGES event when verdict is REQUEST_CHANGES', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'Found issues.\n\nVerdict: REQUEST_CHANGES' }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.equal(JSON.parse(review.body).event, 'REQUEST_CHANGES');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review defaults to REQUEST_CHANGES when verdict is absent from LLM response', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'No verdict line in this response.' }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.equal(JSON.parse(review.body).event, 'REQUEST_CHANGES');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review detects APPROVE when verdict is a markdown heading with value on next line', async () => {
+  const groqContent = '### ✅ Summary\nLooks good.\n\n### 🚀 Verdict\nAPPROVED';
+  const server = await startMockServer(makeHandler({ groqContent }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.equal(JSON.parse(review.body).event, 'APPROVE');
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});
@@ -204,9 +310,11 @@ test('pr_review prepends heading when LLM response does not include it', async (
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    const upsert = server.requests.find((r) => (r.method === 'POST' || r.method === 'PATCH') && r.url.includes('/comments'));
-    assert.ok(upsert, 'expected a comment upsert request');
-    const { body } = JSON.parse(upsert.body);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    const { body } = JSON.parse(review.body);
     assert.ok(body.startsWith(HEADING), `expected body to start with heading, got: ${body.slice(0, 80)}`);
   } finally {
     server.close();
@@ -221,9 +329,11 @@ test('pr_review does not duplicate heading when LLM response already contains it
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    const upsert = server.requests.find((r) => (r.method === 'POST' || r.method === 'PATCH') && r.url.includes('/comments'));
-    assert.ok(upsert, 'expected a comment upsert request');
-    const { body } = JSON.parse(upsert.body);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    const { body } = JSON.parse(review.body);
     const occurrences = body.split(HEADING).length - 1;
     assert.equal(occurrences, 1, `heading should appear exactly once, found ${occurrences} times`);
   } finally {
@@ -232,7 +342,7 @@ test('pr_review does not duplicate heading when LLM response already contains it
   }
 });
 
-test('pr_review applies review-approved and removes changes-requested on APPROVED verdict', async () => {
+test('pr_review applies review-approved label on APPROVED verdict', async () => {
   const server = await startMockServer(
     makeHandler({ groqContent: 'All good.\n\nVerdict: APPROVED' }),
   );
@@ -240,16 +350,11 @@ test('pr_review applies review-approved and removes changes-requested on APPROVE
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-
     const apply = server.requests.find(
       (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
     );
     assert.ok(apply, 'expected POST to issue labels endpoint');
-    assert.ok(
-      JSON.parse(apply.body).labels.includes('review-approved'),
-      'should apply review-approved',
-    );
-
+    assert.ok(JSON.parse(apply.body).labels.includes('review-approved'), 'should apply review-approved');
     const remove = server.requests.find(
       (r) => r.method === 'DELETE' && r.url.includes('/labels/changes-requested'),
     );
@@ -260,7 +365,7 @@ test('pr_review applies review-approved and removes changes-requested on APPROVE
   }
 });
 
-test('pr_review applies changes-requested and removes review-approved on REQUEST_CHANGES verdict', async () => {
+test('pr_review applies changes-requested label on REQUEST_CHANGES verdict', async () => {
   const server = await startMockServer(
     makeHandler({ groqContent: 'Found issues.\n\nVerdict: REQUEST_CHANGES' }),
   );
@@ -268,64 +373,15 @@ test('pr_review applies changes-requested and removes review-approved on REQUEST
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-
     const apply = server.requests.find(
       (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
     );
     assert.ok(apply, 'expected POST to issue labels endpoint');
-    assert.ok(
-      JSON.parse(apply.body).labels.includes('changes-requested'),
-      'should apply changes-requested',
-    );
-
+    assert.ok(JSON.parse(apply.body).labels.includes('changes-requested'), 'should apply changes-requested');
     const remove = server.requests.find(
       (r) => r.method === 'DELETE' && r.url.includes('/labels/review-approved'),
     );
     assert.ok(remove, 'expected DELETE for review-approved');
-  } finally {
-    server.close();
-    await fs.unlink(eventFile).catch(() => {});
-  }
-});
-
-test('pr_review detects APPROVED when verdict is a markdown heading with value on next line', async () => {
-  const groqContent = '### ✅ Summary\nLooks good.\n\n### 🚀 Verdict\nAPPROVED';
-  const server = await startMockServer(makeHandler({ groqContent }));
-  const eventFile = await writeEventFile();
-  try {
-    const result = await runPrReview(server.address().port, eventFile);
-    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    const apply = server.requests.find(
-      (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
-    );
-    assert.ok(apply, 'expected POST to issue labels endpoint');
-    assert.ok(
-      JSON.parse(apply.body).labels.includes('review-approved'),
-      'should apply review-approved for heading-style APPROVED verdict',
-    );
-  } finally {
-    server.close();
-    await fs.unlink(eventFile).catch(() => {});
-  }
-});
-
-test('pr_review defaults to changes-requested when verdict is absent from LLM response', async () => {
-  const server = await startMockServer(
-    makeHandler({ groqContent: 'No verdict line in this response.' }),
-  );
-  const eventFile = await writeEventFile();
-  try {
-    const result = await runPrReview(server.address().port, eventFile);
-    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-
-    const apply = server.requests.find(
-      (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
-    );
-    assert.ok(apply, 'expected POST to issue labels endpoint');
-    assert.ok(
-      JSON.parse(apply.body).labels.includes('changes-requested'),
-      'should default to changes-requested',
-    );
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});
@@ -340,7 +396,6 @@ test('pr_review falls back to PATCH when label POST returns 422', async () => {
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-
     const patches = server.requests.filter(
       (r) => r.method === 'PATCH' && /\/repos\/[^/]+\/[^/]+\/labels\//.test(r.url),
     );

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -41,6 +41,10 @@ function makeHandler({
   commentsStatus = 200,
   commentsBody = '[]',
   upsertStatus = 201,
+  labelCreateStatus = 201,
+  labelUpdateStatus = 200,
+  applyLabelStatus = 200,
+  removeLabelStatus = 200,
 } = {}) {
   return (req, res) => {
     const { method, url } = req;
@@ -63,6 +67,26 @@ function makeHandler({
     if ((method === 'POST' || method === 'PATCH') && url.includes('/comments')) {
       res.writeHead(upsertStatus, { 'Content-Type': 'application/json' });
       return res.end(upsertStatus < 300 ? '{"id":1}' : 'Internal Server Error');
+    }
+
+    if (method === 'POST' && /\/repos\/[^/]+\/[^/]+\/labels$/.test(url)) {
+      res.writeHead(labelCreateStatus, { 'Content-Type': 'application/json' });
+      return res.end(labelCreateStatus < 300 ? '{"id":1,"name":"label"}' : 'error');
+    }
+
+    if (method === 'PATCH' && /\/repos\/[^/]+\/[^/]+\/labels\/[^/]+$/.test(url)) {
+      res.writeHead(labelUpdateStatus, { 'Content-Type': 'application/json' });
+      return res.end(labelUpdateStatus < 300 ? '{"id":1}' : 'error');
+    }
+
+    if (method === 'POST' && /\/issues\/\d+\/labels$/.test(url)) {
+      res.writeHead(applyLabelStatus, { 'Content-Type': 'application/json' });
+      return res.end(applyLabelStatus < 300 ? '[]' : 'error');
+    }
+
+    if (method === 'DELETE' && /\/issues\/\d+\/labels\//.test(url)) {
+      res.writeHead(removeLabelStatus, { 'Content-Type': 'application/json' });
+      return res.end(removeLabelStatus < 300 ? '[]' : 'error');
     }
 
     res.writeHead(404);
@@ -202,6 +226,134 @@ test('pr_review does not duplicate heading when LLM response already contains it
     const { body } = JSON.parse(upsert.body);
     const occurrences = body.split(HEADING).length - 1;
     assert.equal(occurrences, 1, `heading should appear exactly once, found ${occurrences} times`);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review applies review-approved and removes changes-requested on APPROVED verdict', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'All good.\n\nVerdict: APPROVED' }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+    const apply = server.requests.find(
+      (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
+    );
+    assert.ok(apply, 'expected POST to issue labels endpoint');
+    assert.ok(
+      JSON.parse(apply.body).labels.includes('review-approved'),
+      'should apply review-approved',
+    );
+
+    const remove = server.requests.find(
+      (r) => r.method === 'DELETE' && r.url.includes('/labels/changes-requested'),
+    );
+    assert.ok(remove, 'expected DELETE for changes-requested');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review applies changes-requested and removes review-approved on REQUEST_CHANGES verdict', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'Found issues.\n\nVerdict: REQUEST_CHANGES' }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+    const apply = server.requests.find(
+      (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
+    );
+    assert.ok(apply, 'expected POST to issue labels endpoint');
+    assert.ok(
+      JSON.parse(apply.body).labels.includes('changes-requested'),
+      'should apply changes-requested',
+    );
+
+    const remove = server.requests.find(
+      (r) => r.method === 'DELETE' && r.url.includes('/labels/review-approved'),
+    );
+    assert.ok(remove, 'expected DELETE for review-approved');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review defaults to changes-requested when verdict is absent from LLM response', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'No verdict line in this response.' }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+    const apply = server.requests.find(
+      (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
+    );
+    assert.ok(apply, 'expected POST to issue labels endpoint');
+    assert.ok(
+      JSON.parse(apply.body).labels.includes('changes-requested'),
+      'should default to changes-requested',
+    );
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review falls back to PATCH when label POST returns 422', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'Verdict: APPROVED', labelCreateStatus: 422 }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+    const patches = server.requests.filter(
+      (r) => r.method === 'PATCH' && /\/repos\/[^/]+\/[^/]+\/labels\//.test(r.url),
+    );
+    assert.equal(patches.length, 2, 'expected PATCH for both PR review labels');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review exits 1 when label create returns unexpected error', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'Verdict: APPROVED', labelCreateStatus: 500 }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /Label create failed/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review exits 1 when addLabel fails', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'Verdict: APPROVED', applyLabelStatus: 422 }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /Add label.*failed/);
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -288,6 +288,27 @@ test('pr_review applies changes-requested and removes review-approved on REQUEST
   }
 });
 
+test('pr_review detects APPROVED when verdict is a markdown heading with value on next line', async () => {
+  const groqContent = '### ✅ Summary\nLooks good.\n\n### 🚀 Verdict\nAPPROVED';
+  const server = await startMockServer(makeHandler({ groqContent }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const apply = server.requests.find(
+      (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
+    );
+    assert.ok(apply, 'expected POST to issue labels endpoint');
+    assert.ok(
+      JSON.parse(apply.body).labels.includes('review-approved'),
+      'should apply review-approved for heading-style APPROVED verdict',
+    );
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
 test('pr_review defaults to changes-requested when verdict is absent from LLM response', async () => {
   const server = await startMockServer(
     makeHandler({ groqContent: 'No verdict line in this response.' }),

--- a/scripts/tests/yaml.test.mjs
+++ b/scripts/tests/yaml.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseFlatYaml } from '../lib/yaml.mjs';
+import { parseFlatYaml, parseNestedYaml } from '../lib/yaml.mjs';
 
 test('parses simple key: value pairs', () => {
   const result = parseFlatYaml('foo: bar\nbaz: qux');
@@ -53,4 +53,91 @@ test('parses models.yaml keys correctly', () => {
   assert.equal(result.validation, 'llama-3.3-70b-versatile');
   assert.equal(result.generation, 'llama-3.1-8b-instant');
   assert.equal(result.review, 'llama-3.3-70b-versatile');
+});
+
+// parseNestedYaml tests
+
+test('parseNestedYaml parses 3-level nested structure', () => {
+  const yaml = [
+    'issue:',
+    '  valid:',
+    '    name: ready-for-dev',
+    '    color: 0075ca',
+  ].join('\n');
+  const result = parseNestedYaml(yaml);
+  assert.deepEqual(result, { issue: { valid: { name: 'ready-for-dev', color: '0075ca' } } });
+});
+
+test('parseNestedYaml parses multiple groups and sections', () => {
+  const yaml = [
+    'issue:',
+    '  valid:',
+    '    name: ready-for-dev',
+    '  invalid:',
+    '    name: needs-refinement',
+    'review:',
+    '  approved:',
+    '    name: review-approved',
+  ].join('\n');
+  const result = parseNestedYaml(yaml);
+  assert.equal(result.issue.valid.name, 'ready-for-dev');
+  assert.equal(result.issue.invalid.name, 'needs-refinement');
+  assert.equal(result.review.approved.name, 'review-approved');
+});
+
+test('parseNestedYaml ignores blank lines and comments', () => {
+  const yaml = [
+    '# top comment',
+    'issue:',
+    '  # section comment',
+    '  valid:',
+    '',
+    '    name: ready-for-dev',
+  ].join('\n');
+  const result = parseNestedYaml(yaml);
+  assert.equal(result.issue.valid.name, 'ready-for-dev');
+});
+
+test('parseNestedYaml handles values containing colons', () => {
+  const yaml = [
+    'group:',
+    '  key:',
+    '    url: https://example.com/path',
+  ].join('\n');
+  const result = parseNestedYaml(yaml);
+  assert.equal(result.group.key.url, 'https://example.com/path');
+});
+
+test('parseNestedYaml returns empty object for empty input', () => {
+  assert.deepEqual(parseNestedYaml(''), {});
+});
+
+test('parseNestedYaml parses labels.yaml structure correctly', () => {
+  const yaml = [
+    'issue:',
+    '  valid:',
+    '    name: ready-for-dev',
+    '    color: 0075ca',
+    '    description: Issue validated and ready for automated implementation',
+    '  invalid:',
+    '    name: needs-refinement',
+    '    color: e4e669',
+    '    description: Issue requires clearer acceptance criteria before automation',
+    'review:',
+    '  approved:',
+    '    name: review-approved',
+    '    color: 0e8a16',
+    '    description: Automated code review passed without requested changes',
+    '  changes:',
+    '    name: changes-requested',
+    '    color: d93f0b',
+    '    description: Automated code review found issues requiring changes',
+  ].join('\n');
+  const result = parseNestedYaml(yaml);
+  assert.equal(result.issue.valid.name, 'ready-for-dev');
+  assert.equal(result.issue.valid.color, '0075ca');
+  assert.equal(result.issue.invalid.name, 'needs-refinement');
+  assert.equal(result.review.approved.name, 'review-approved');
+  assert.equal(result.review.changes.name, 'changes-requested');
+  assert.equal(result.review.changes.color, 'd93f0b');
 });


### PR DESCRIPTION
Mirrors the issue review label pattern: after posting the automated review
comment, pr_review.mjs parses the LLM verdict and applies either
`review-approved` (green) or `changes-requested` (red) to the PR,
removing the other label. Defaults conservatively to `changes-requested`
when no verdict is found.

https://claude.ai/code/session_01QKyetzV15bzJhiTBCW32ds