### PR TITLE
rename "AI Issue to PR" to "Code Generation" everywhere

### DIFF
--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -1,4 +1,4 @@
-name: AI Issue to PR
+name: Code Generation
 
 on:
   issues:
@@ -77,4 +77,3 @@ jobs:
             Closes #${{ steps.issue.outputs.number }}
           add-paths: |
             ${{ steps.generate.outputs.generated_paths }}
-

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -49,12 +49,12 @@ jobs:
           IS_VALID: ${{ steps.validate.outputs.valid }}
         run: node scripts/manage_labels.mjs
 
-      - name: Trigger AI Issue to PR
+      - name: Trigger Code Generation
         if: steps.validate.outputs.valid == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run ai-issue-to-pr.yml \
+          gh workflow run code-generation.yml \
             --repo "${{ github.repository }}" \
             --ref "${{ github.event.repository.default_branch }}" \
             -f issue_number=${{ github.event.issue.number }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides working conventions for AI agents contributing to this reposi
 
 Two distinct agent types operate here:
 - **Interactive agents** (e.g. Claude Code): assist developers directly on the codebase.
-- **Pipeline agent**: the automated `ai-issue-to-pr` workflow that generates file changes from issues.
+- **Pipeline agent**: the automated `code-generation` workflow that generates file changes from issues.
 
 Rules marked _(pipeline only)_ apply exclusively to the automated pipeline. All other rules apply to both.
 
@@ -42,5 +42,5 @@ Before committing any change to `scripts/` or `prompts/`:
 
 ## Documentation Rules
 
-- Update `docs/ai-issue-to-pr.md` when workflow inputs or setup requirements change.
+- Update `docs/code-generation.md` when workflow inputs or setup requirements change.
 - Record major architectural decisions in `docs/adr/` as numbered ADR files.

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ A fully autonomous GitHub-native dev loop: Issue → AI coder → PR → AI revi
 
 The MVP issue-to-PR automation is now implemented. The default AI provider is **Anthropic** (Claude); Groq is also supported via the `AI_PROVIDER` variable.
 
-- Workflow: `.github/workflows/ai-issue-to-pr.yml` (kept minimal/orchestration-only)
+- Workflow: `.github/workflows/code-generation.yml` (kept minimal/orchestration-only)
 - Generator script: `scripts/generate_issue_change.mjs`
 - Generator modules: `scripts/lib/*.mjs`
 - Prompt files: `prompts/*.md` (one file per prompt, loaded at runtime)
-- Setup and testing guide: `docs/ai-issue-to-pr.md`
+- Setup and testing guide: `docs/code-generation.md`
 - MVP definition: `docs/mvp.md`
 
-See `docs/ai-issue-to-pr.md` for required secrets (`ANTHROPIC_API_KEY` or `GROQ_API_KEY`), recommended PR token (`AI_PR_TOKEN`), optional variables, label configuration, end-to-end test steps, and risk/mitigation notes.
+See `docs/code-generation.md` for required secrets (`ANTHROPIC_API_KEY` or `GROQ_API_KEY`), recommended PR token (`AI_PR_TOKEN`), optional variables, label configuration, end-to-end test steps, and risk/mitigation notes.
 
 
 ## Tests

--- a/docs/adr/0004-pr-authentication-token-strategy.md
+++ b/docs/adr/0004-pr-authentication-token-strategy.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-The workflow opens pull requests from GitHub Actions (`.github/workflows/ai-issue-to-pr.yml`).
+The workflow opens pull requests from GitHub Actions (`.github/workflows/code-generation.yml`).
 Some repositories/organizations disable the setting that allows `GITHUB_TOKEN` to create or approve PRs.
 In that configuration, the run fails with:
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -1,10 +1,10 @@
-# AI Issue-to-PR MVP Setup
+# Code Generation MVP Setup
 
 This repository includes an MVP workflow that converts validated issues into AI-generated draft pull requests. The default AI provider is **Anthropic** (Claude models). Groq is also supported and can be selected via the `AI_PROVIDER` environment variable. The workflow triggers automatically when the validation agent applies the `ready-for-dev` label.
 
 ## Workflow Overview
 
-File: `.github/workflows/ai-issue-to-pr.yml`
+File: `.github/workflows/code-generation.yml`
 
 Workflow design note: YAML stays intentionally minimal (orchestration only). Most logic lives in Node modules for future unit testing.
 
@@ -76,7 +76,7 @@ All label names, colors, and descriptions are configurable in `config/labels.yam
 1. Ensure secrets above are configured.
 2. Create a new GitHub issue using the feature or bug template, with a clear title and body.
 3. Open **Actions** and confirm run `Issue Validation Agent` starts.
-4. Once validation passes, confirm `AI Issue to PR` starts automatically from the `ready-for-dev` label event.
+4. Once validation passes, confirm `Code Generation` starts automatically from the `ready-for-dev` label event.
 5. Verify logs for:
    - prompt construction
    - LLM API call success


### PR DESCRIPTION
Renames the workflow file, docs file, and all textual references
(README, AGENTS, validate-issue workflow, ADR-0004) from the
old name to the clearer, implementation-neutral "Code Generation".

https://claude.ai/code/session_01HmaUcFPghJGJBzyKEDDt7G