### PR TITLE
fix: remove hard-coded label strings from workflow and tests

### DIFF
--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -16,10 +16,30 @@ permissions:
   issues: write
 
 jobs:
+  load-labels:
+    runs-on: ubuntu-latest
+    outputs:
+      ready_for_dev: ${{ steps.cfg.outputs.ready_for_dev }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - id: cfg
+        run: |
+          LABEL=$(node --input-type=module <<'EOF'
+          import { readFileSync } from 'fs';
+          import { parseNestedYaml } from './scripts/lib/yaml.mjs';
+          process.stdout.write(parseNestedYaml(readFileSync('config/labels.yaml', 'utf8')).issue.valid.name);
+          EOF
+          )
+          echo "ready_for_dev=$LABEL" >> "$GITHUB_OUTPUT"
+
   generate-pr:
+    needs: load-labels
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'ready-for-dev'
+      github.event.label.name == needs.load-labels.outputs.ready_for_dev
     runs-on: ubuntu-latest
 
     steps:

--- a/scripts/tests/manage_labels.test.mjs
+++ b/scripts/tests/manage_labels.test.mjs
@@ -1,11 +1,15 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import http from 'node:http';
+import { parseNestedYaml } from '../lib/yaml.mjs';
 
 const SCRIPTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_DIR = path.join(SCRIPTS_DIR, '..');
+const LABELS = parseNestedYaml(readFileSync(path.join(ROOT_DIR, 'config/labels.yaml'), 'utf8'));
 
 function startMockServer(handler) {
   const requests = [];
@@ -97,12 +101,12 @@ test('manage_labels IS_VALID=true applies ready-for-dev and removes needs-refine
       (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
     );
     assert.ok(apply, 'expected POST to issue labels endpoint');
-    assert.ok(JSON.parse(apply.body).labels.includes('ready-for-dev'), 'should apply ready-for-dev');
+    assert.ok(JSON.parse(apply.body).labels.includes(LABELS.issue.valid.name), `should apply ${LABELS.issue.valid.name}`);
 
     const remove = server.requests.find(
-      (r) => r.method === 'DELETE' && r.url.includes('/labels/needs-refinement'),
+      (r) => r.method === 'DELETE' && r.url.includes(`/labels/${LABELS.issue.invalid.name}`),
     );
-    assert.ok(remove, 'expected DELETE for needs-refinement');
+    assert.ok(remove, `expected DELETE for ${LABELS.issue.invalid.name}`);
   } finally {
     server.close();
   }
@@ -117,12 +121,12 @@ test('manage_labels IS_VALID=false applies needs-refinement and removes ready-fo
     const apply = server.requests.find(
       (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
     );
-    assert.ok(JSON.parse(apply.body).labels.includes('needs-refinement'), 'should apply needs-refinement');
+    assert.ok(JSON.parse(apply.body).labels.includes(LABELS.issue.invalid.name), `should apply ${LABELS.issue.invalid.name}`);
 
     const remove = server.requests.find(
-      (r) => r.method === 'DELETE' && r.url.includes('/labels/ready-for-dev'),
+      (r) => r.method === 'DELETE' && r.url.includes(`/labels/${LABELS.issue.valid.name}`),
     );
-    assert.ok(remove, 'expected DELETE for ready-for-dev');
+    assert.ok(remove, `expected DELETE for ${LABELS.issue.valid.name}`);
   } finally {
     server.close();
   }

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -1,13 +1,17 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import http from 'node:http';
+import { parseNestedYaml } from '../lib/yaml.mjs';
 
 const SCRIPTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const ROOT_DIR = path.join(SCRIPTS_DIR, '..');
+const LABELS = parseNestedYaml(readFileSync(path.join(ROOT_DIR, 'config/labels.yaml'), 'utf8'));
 const HEADING = '## 🔍 Automated Code Review';
 const PR_NUMBER = 42;
 const COMMENT_ID = 999;
@@ -367,11 +371,11 @@ test('pr_review applies review-approved label on APPROVED verdict', async () => 
       (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
     );
     assert.ok(apply, 'expected POST to issue labels endpoint');
-    assert.ok(JSON.parse(apply.body).labels.includes('review-approved'), 'should apply review-approved');
+    assert.ok(JSON.parse(apply.body).labels.includes(LABELS.review.approved.name), `should apply ${LABELS.review.approved.name}`);
     const remove = server.requests.find(
-      (r) => r.method === 'DELETE' && r.url.includes('/labels/changes-requested'),
+      (r) => r.method === 'DELETE' && r.url.includes(`/labels/${LABELS.review.changes.name}`),
     );
-    assert.ok(remove, 'expected DELETE for changes-requested');
+    assert.ok(remove, `expected DELETE for ${LABELS.review.changes.name}`);
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});
@@ -390,11 +394,11 @@ test('pr_review applies changes-requested label on REQUEST_CHANGES verdict', asy
       (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
     );
     assert.ok(apply, 'expected POST to issue labels endpoint');
-    assert.ok(JSON.parse(apply.body).labels.includes('changes-requested'), 'should apply changes-requested');
+    assert.ok(JSON.parse(apply.body).labels.includes(LABELS.review.changes.name), `should apply ${LABELS.review.changes.name}`);
     const remove = server.requests.find(
-      (r) => r.method === 'DELETE' && r.url.includes('/labels/review-approved'),
+      (r) => r.method === 'DELETE' && r.url.includes(`/labels/${LABELS.review.approved.name}`),
     );
-    assert.ok(remove, 'expected DELETE for review-approved');
+    assert.ok(remove, `expected DELETE for ${LABELS.review.approved.name}`);
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});


### PR DESCRIPTION
code-generation.yml now loads the ready-for-dev label name from
config/labels.yaml via a load-labels job instead of embedding the
string directly in the job condition.

Test assertions in manage_labels and pr_review tests now read label
names from config/labels.yaml via parseNestedYaml so label renames
propagate automatically.

https://claude.ai/code/session_017gq1M6ssbda5eWLeaAh5Pr