### PR TITLE
feat: add iterative auto-fix workflow and fix duplicate PR review comment

### DIFF
--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -1,0 +1,49 @@
+name: Auto-Fix PR
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-fix:
+    if: github.event.review.state == 'changes_requested'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.AI_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Apply AI fixes
+        id: fix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GROQ_MODEL: ${{ vars.GROQ_MODEL }}
+          GROQ_API_URL: ${{ vars.GROQ_API_URL }}
+        run: node scripts/auto_fix_pr.mjs
+
+      - name: Commit and push fixes
+        if: steps.fix.outputs.fixed_paths != ''
+        env:
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          ATTEMPT: ${{ steps.fix.outputs.attempt_number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "fix(ai): auto-fix attempt ${ATTEMPT}"
+          git push origin HEAD:"${PR_BRANCH}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,15 @@ Before committing any change to `scripts/` or `prompts/`:
 - PR descriptions should include `Closes #<issue_number>`.
 - Do not implement auto-merge in MVP.
 
+## Auto-Fix Rules _(pipeline only)_
+
+- The auto-fix workflow (`auto-fix-pr.yml`) triggers on any `pull_request_review` event where `review.state == 'changes_requested'`, regardless of whether the reviewer is the automated bot or a human.
+- The maximum number of auto-fix attempts per PR is **3**, tracked via `auto-fix-attempt-N` labels on the PR.
+- When the attempt limit is reached, the workflow posts a comment and exits without making any changes.
+- Auto-fix commits use the message format `fix(ai): auto-fix attempt N`.
+- Auto-fix only addresses issues explicitly named in the review feedback. It does not make speculative improvements.
+
 ## Documentation Rules
 
-- Update `docs/code-generation.md` when workflow inputs or setup requirements change.
+- Update `docs/code-generation.md` when workflow inputs, setup requirements, or pipeline behavior change.
 - Record major architectural decisions in `docs/adr/` as numbered ADR files.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ The MVP issue-to-PR automation is now implemented. The default AI provider is **
 
 See `docs/code-generation.md` for required secrets (`ANTHROPIC_API_KEY` or `GROQ_API_KEY`), recommended PR token (`AI_PR_TOKEN`), optional variables, label configuration, end-to-end test steps, and risk/mitigation notes.
 
+## Iterative Review Loop
+
+Once a PR is opened, the automation continues:
+
+1. **PR Review** (`.github/workflows/pr-review.yml`) — triggered on every push to the PR branch. Posts or updates a review comment and submits an `APPROVE` or `REQUEST_CHANGES` verdict.
+2. **Auto-Fix** (`.github/workflows/auto-fix-pr.yml`) — triggered when a review requests changes. Reads the review feedback, generates targeted fixes using the LLM, and pushes them back to the PR branch — re-triggering the review.
+
+The loop runs up to **3 auto-fix iterations** per PR. After that, a comment is posted requesting manual intervention.
+
 
 ## Tests
 

--- a/config/labels.yaml
+++ b/config/labels.yaml
@@ -20,3 +20,17 @@ review:
     name: changes-requested
     color: d93f0b
     description: Automated code review found issues requiring changes
+
+autofix:
+  attempt1:
+    name: auto-fix-attempt-1
+    color: fbca04
+    description: Auto-fix iteration 1 applied
+  attempt2:
+    name: auto-fix-attempt-2
+    color: fbca04
+    description: Auto-fix iteration 2 applied
+  attempt3:
+    name: auto-fix-attempt-3
+    color: fbca04
+    description: Auto-fix iteration 3 applied

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -5,3 +5,4 @@
 validation: llama-3.3-70b-versatile
 generation: llama-3.3-70b-versatile
 review:     llama-3.3-70b-versatile
+autofix:    llama-3.3-70b-versatile

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -114,8 +114,41 @@ The workflow runs on pull requests (`opened`, `synchronize`, `reopened`) with pe
 
 On each run it:
 1. Fetches the PR diff and calls the LLM for a structured review.
-2. Posts or updates a comment on the PR with the full review text.
-3. Submits an official GitHub pull request review with event `APPROVE` or `REQUEST_CHANGES` based on the verdict in the LLM response.
+2. Posts or updates a single comment on the PR with the full review text (existing review comments are updated in place).
+3. Submits an official GitHub pull request review event (`APPROVE` or `REQUEST_CHANGES`) with a short redirect body. The full review detail lives only in the comment, preventing duplicate content from appearing in the PR conversation.
 4. Applies the label `review-approved` or `changes-requested` to the PR (and removes the other).
 
 **Review submission permission:** submitting a GitHub review requires the repository setting **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** to be enabled. If it is not enabled, the review submission is skipped with a warning (the comment and labels are still applied). This is the same setting used for PR creation by the generation workflow.
+
+## Auto-Fix Workflow
+
+File: `.github/workflows/auto-fix-pr.yml`
+
+Node implementation:
+- Entrypoint: `scripts/auto_fix_pr.mjs`
+- Prompts: `prompts/auto-fix-system.md`, `prompts/auto-fix-user.md`
+
+Required secret:
+- **Secret**: `GROQ_API_KEY` (or `ANTHROPIC_API_KEY`) — same provider selection rules apply (see above).
+
+The workflow triggers on `pull_request_review` events of type `submitted` where `review.state == 'changes_requested'`. This fires whether the reviewer is the automated review bot or a human.
+
+On each run it:
+1. Checks the PR for `auto-fix-attempt-N` labels to determine how many auto-fix cycles have already run.
+2. If the attempt count has reached the maximum (3), posts a comment explaining that the limit is exhausted and exits without making changes.
+3. Fetches the review body and any inline review comments to build the full feedback context.
+4. Fetches the current PR diff and reads the changed files from disk (up to 10 files, capped at 8 000 chars each).
+5. Calls the LLM with the review feedback, diff, and current file contents to generate targeted fixes.
+6. Writes 1 to 6 fixed files to the PR branch, commits, and pushes.
+7. Applies the `auto-fix-attempt-N` label to the PR for tracking.
+8. The push triggers a new `synchronize` event on the PR, which re-runs the PR Review workflow — closing the iterative loop.
+
+**Iteration limit:** the loop runs at most 3 times per PR. After 3 auto-fix attempts, the workflow posts a comment asking for manual intervention.
+
+**Required label:**
+
+The auto-fix workflow creates and manages these labels automatically:
+
+- `auto-fix-attempt-1`, `auto-fix-attempt-2`, `auto-fix-attempt-3` — each applied after the corresponding fix cycle completes.
+
+All label names, colors, and descriptions are configurable in `config/labels.yaml` under the `autofix` key.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,10 +20,11 @@ Requires Node.js 20+. All tests should pass in under a second.
 | `scripts/lib/anthropic_client.mjs` | 10 | HTTP errors, non-JSON response, malformed `content`, `x-api-key` header, `anthropic-version` header, temperature, `max_tokens`, system prompt placement |
 | `scripts/lib/llm_client.mjs` | 4 | Default routes to Anthropic, explicit `AI_PROVIDER=groq` routes to Groq, `AI_PROVIDER=anthropic` routes to Anthropic, case-insensitivity |
 | `scripts/lib/issue_validator.mjs` | 51 | `VALIDATION_SYSTEM_PROMPT` structure, `isMeaningfulTitle` edge cases, `buildValidationUserPrompt` edge cases, `parseGroqResponse` hard rules and error cases, `formatGitHubComment` formatting, `validateIssue` integration (including prefix-only title short-circuit) |
-| `scripts/lib/prompts.mjs` + `prompts/*.md` | 22 | `loadPrompt` for all 6 prompt files, `interpolatePrompt` placeholder substitution, per-file content assertions (keywords, placeholders, length) |
+| `scripts/lib/prompts.mjs` + `prompts/*.md` | 22 | `loadPrompt` for all 8 prompt files, `interpolatePrompt` placeholder substitution, per-file content assertions (keywords, placeholders, length) |
 | `scripts/lib/yaml.mjs` | 15 | `parseFlatYaml` key/value parsing, blank lines, comments, colons in values; `parseNestedYaml` 3-level nesting, multiple groups, `labels.yaml` structure |
 | `scripts/manage_labels.mjs` | 8 | Label upsert (create + PATCH fallback), apply/remove swap for `IS_VALID=true/false`, error cases (create 500, PATCH 500, add 422, remove 500), 404 on remove treated as success |
-| `scripts/pr_review.mjs` | 19 | Diff fetch errors, comment list/upsert errors, review submit errors (500 fatal, 422 warning), APPROVE/REQUEST_CHANGES event, heading-style verdict detection, label swap, PATCH fallback on label 422 |
+| `scripts/pr_review.mjs` | 20 | Diff fetch errors, comment list/upsert errors, review submit errors (500 fatal, 422 warning), APPROVE/REQUEST_CHANGES event, heading-style verdict detection, label swap, PATCH fallback on label 422, short review body distinct from comment body |
+| `scripts/auto_fix_pr.mjs` | 10 | Label list fetch error, max-attempts guard (exits 0, posts exhausted comment), diff fetch error, invalid LLM JSON, empty changes array, success path (file written + attempt-1 label applied), attempt counter increment, inline comment inclusion in prompt, graceful inline comment fetch failure, attempt label repo creation |
 
 ## Prompt Files
 
@@ -37,6 +38,8 @@ All AI prompts live in `prompts/` as `.md` files, one per prompt:
 | `generation-user.md` | `config.mjs` | Placeholders: `{{issueNumber}}`, `{{issueTitle}}`, `{{issueBody}}` |
 | `pr-review-system.md` | `scripts/pr_review.mjs` | Reviewer persona |
 | `pr-review-user.md` | `scripts/pr_review.mjs` | Placeholder: `{{diff}}` |
+| `auto-fix-system.md` | `scripts/auto_fix_pr.mjs` | Fix-only persona, hard output-format rules |
+| `auto-fix-user.md` | `scripts/auto_fix_pr.mjs` | Placeholders: `{{reviewFeedback}}`, `{{diff}}`, `{{fileContents}}` |
 
 Template placeholders use the `{{variableName}}` syntax. `interpolatePrompt()` in `scripts/lib/prompts.mjs` handles substitution; unknown placeholders are left unchanged.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,10 +20,10 @@ Requires Node.js 20+. All tests should pass in under a second.
 | `scripts/lib/anthropic_client.mjs` | 10 | HTTP errors, non-JSON response, malformed `content`, `x-api-key` header, `anthropic-version` header, temperature, `max_tokens`, system prompt placement |
 | `scripts/lib/llm_client.mjs` | 4 | Default routes to Anthropic, explicit `AI_PROVIDER=groq` routes to Groq, `AI_PROVIDER=anthropic` routes to Anthropic, case-insensitivity |
 | `scripts/lib/issue_validator.mjs` | 51 | `VALIDATION_SYSTEM_PROMPT` structure, `isMeaningfulTitle` edge cases, `buildValidationUserPrompt` edge cases, `parseGroqResponse` hard rules and error cases, `formatGitHubComment` formatting, `validateIssue` integration (including prefix-only title short-circuit) |
-| `scripts/lib/prompts.mjs` + `prompts/*.md` | 22 | `loadPrompt` for all 8 prompt files, `interpolatePrompt` placeholder substitution, per-file content assertions (keywords, placeholders, length) |
+| `scripts/lib/prompts.mjs` + `prompts/*.md` | 28 | `loadPrompt` for all 8 prompt files, `interpolatePrompt` placeholder substitution, per-file content assertions (keywords, placeholders, length) |
 | `scripts/lib/yaml.mjs` | 15 | `parseFlatYaml` key/value parsing, blank lines, comments, colons in values; `parseNestedYaml` 3-level nesting, multiple groups, `labels.yaml` structure |
 | `scripts/manage_labels.mjs` | 8 | Label upsert (create + PATCH fallback), apply/remove swap for `IS_VALID=true/false`, error cases (create 500, PATCH 500, add 422, remove 500), 404 on remove treated as success |
-| `scripts/pr_review.mjs` | 20 | Diff fetch errors, comment list/upsert errors, review submit errors (500 fatal, 422 warning), APPROVE/REQUEST_CHANGES event, heading-style verdict detection, label swap, PATCH fallback on label 422, short review body distinct from comment body |
+| `scripts/pr_review.mjs` | 24 | Diff fetch errors, comment list/upsert errors, review submit errors (500 fatal, 422 warning), APPROVE/REQUEST_CHANGES event, heading-style and bold-markdown verdict detection, template-echo placeholder defaults to REQUEST_CHANGES, label swap, PATCH fallback on label 422, short review body distinct from comment body |
 | `scripts/auto_fix_pr.mjs` | 10 | Label list fetch error, max-attempts guard (exits 0, posts exhausted comment), diff fetch error, invalid LLM JSON, empty changes array, success path (file written + attempt-1 label applied), attempt counter increment, inline comment inclusion in prompt, graceful inline comment fetch failure, attempt label repo creation |
 
 ## Prompt Files

--- a/prompts/auto-fix-system.md
+++ b/prompts/auto-fix-system.md
@@ -1,0 +1,11 @@
+You are a senior engineer applying targeted fixes to a pull request based on reviewer feedback.
+
+Rules:
+* Fix only the specific issues explicitly described in the review feedback. Do not make unrelated changes.
+* When modifying an existing file, incorporate your changes into the provided current content — do not rewrite from scratch.
+* Every fix must be independently justified by a specific point in the review feedback.
+* Return strict JSON with exactly two keys: summary and changes.
+* changes must contain 1 to 6 objects — never more. Each object must have target_path and file_content.
+* target_path must be a safe relative path (no absolute paths, no .. traversal).
+* file_content must be the complete, valid file content after the fix is applied.
+* Do not add explanations, comments, or metadata outside the required JSON output.

--- a/prompts/auto-fix-user.md
+++ b/prompts/auto-fix-user.md
@@ -1,0 +1,17 @@
+Apply fixes to the pull request based on the following review feedback.
+
+## Review Feedback
+
+{{reviewFeedback}}
+
+## Current PR Diff
+
+{{diff}}
+
+## Current File Contents
+
+{{fileContents}}
+
+Fix only the issues explicitly mentioned in the review feedback. Use the current file contents as the authoritative base — preserve all content not targeted by the review.
+
+Output JSON only: { "summary": "One sentence summary of the fixes applied", "changes": [ { "target_path": "relative/path/to/file.ext", "file_content": "Complete corrected file content" } ] }

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+import { requireEnv, loadLLMConfig } from './lib/config.mjs';
+import { callLLM } from './lib/llm_client.mjs';
+import { filterDiff, shouldIncludeFile } from './lib/file_filters.mjs';
+import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
+import { validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
+import { log, error as logError } from './lib/logger.mjs';
+
+const MAX_ATTEMPTS = 3;
+const MAX_FILE_SIZE = 8000;
+const ATTEMPT_LABEL_PREFIX = 'auto-fix-attempt-';
+
+const githubToken = requireEnv('GITHUB_TOKEN');
+const repository = requireEnv('GITHUB_REPOSITORY');
+const eventPath = requireEnv('GITHUB_EVENT_PATH');
+const { apiKey: llmApiKey, model, apiUrl } = loadLLMConfig('autofix');
+
+let event;
+try {
+  event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+} catch (err) {
+  throw new Error(`Failed to parse GitHub event payload: ${err.message}`);
+}
+if (!event || typeof event !== 'object') throw new Error('GitHub event payload is not a valid object');
+
+const prNumber = event.pull_request?.number;
+if (!prNumber) throw new Error('Missing pull_request.number in event payload');
+
+const reviewBody = (event.review?.body || '').trim();
+const reviewId = event.review?.id;
+
+const [owner, repo] = repository.split('/');
+const githubApiBase = (process.env.GITHUB_API_URL || 'https://api.github.com').trim();
+
+const githubHeaders = {
+  Authorization: `Bearer ${githubToken}`,
+  'Content-Type': 'application/json',
+  'X-GitHub-Api-Version': '2022-11-28',
+};
+
+async function ghFetch(endpoint, options = {}) {
+  try {
+    return await fetch(`${githubApiBase}${endpoint}`, {
+      ...options,
+      headers: { ...githubHeaders, ...(options.headers || {}) },
+    });
+  } catch (err) {
+    throw new Error(`Network error calling GitHub API (${endpoint}): ${err.message}`);
+  }
+}
+
+const labelsRes = await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/labels`);
+if (!labelsRes.ok) throw new Error(`Label list failed: ${labelsRes.status}`);
+const prLabels = await labelsRes.json();
+const attemptCount = prLabels.filter((l) => l.name.startsWith(ATTEMPT_LABEL_PREFIX)).length;
+
+if (attemptCount >= MAX_ATTEMPTS) {
+  const exhaustedBody = `## 🤖 Auto-Fix Exhausted\n\nMaximum auto-fix attempts (${MAX_ATTEMPTS}) reached on this PR. Please review the remaining issues manually.`;
+  await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, {
+    method: 'POST',
+    body: JSON.stringify({ body: exhaustedBody }),
+  });
+  log('Max auto-fix attempts reached', { prNumber, attemptCount });
+  process.exit(0);
+}
+
+const nextAttempt = attemptCount + 1;
+log('Starting auto-fix', { prNumber, attempt: nextAttempt });
+
+const feedbackParts = [];
+if (reviewBody) feedbackParts.push(reviewBody);
+
+if (reviewId) {
+  const inlineRes = await ghFetch(
+    `/repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments`,
+  );
+  if (inlineRes.ok) {
+    const inlineComments = await inlineRes.json();
+    for (const c of inlineComments) {
+      feedbackParts.push(`**${c.path}** (line ${c.original_line || c.line || '?'}):\n${c.body}`);
+    }
+  }
+}
+
+const reviewFeedback =
+  feedbackParts.join('\n\n---\n\n') || '(No specific review feedback provided)';
+
+const diffRes = await ghFetch(`/repos/${owner}/${repo}/pulls/${prNumber}`, {
+  headers: { Accept: 'application/vnd.github.v3.diff' },
+});
+if (!diffRes.ok) throw new Error(`Diff fetch failed: ${diffRes.status}`);
+const rawDiff = await diffRes.text();
+const diff = filterDiff(rawDiff);
+
+const changedFiles = [
+  ...new Set([...rawDiff.matchAll(/^diff --git a\/(.*?) b\//gm)].map((m) => m[1])),
+].filter(shouldIncludeFile);
+
+const repoRoot = path.resolve(process.cwd());
+const fileContentParts = [];
+for (const filePath of changedFiles.slice(0, 10)) {
+  const absPath = path.resolve(repoRoot, filePath);
+  if (!absPath.startsWith(repoRoot + path.sep)) continue;
+  try {
+    const content = await fsPromises.readFile(absPath, 'utf8');
+    fileContentParts.push(
+      `### Current file: ${filePath}\n\`\`\`\n${content.slice(0, MAX_FILE_SIZE)}\n\`\`\``,
+    );
+  } catch {
+    // File deleted or unreadable — skip
+  }
+}
+const fileContents =
+  fileContentParts.length > 0
+    ? fileContentParts.join('\n\n')
+    : 'No existing files identified as relevant to this review.';
+
+const systemPrompt = loadPrompt('auto-fix-system');
+const userPrompt = interpolatePrompt(loadPrompt('auto-fix-user'), {
+  reviewFeedback,
+  diff,
+  fileContents,
+});
+
+const raw = await callLLM({
+  prompt: userPrompt,
+  systemPrompt,
+  apiKey: llmApiKey,
+  model,
+  apiUrl,
+  temperature: 0.2,
+  responseFormat: null,
+});
+
+let aiOutput;
+try {
+  aiOutput = JSON.parse(raw);
+} catch {
+  throw new Error('AI response was not valid JSON');
+}
+if (!aiOutput || typeof aiOutput !== 'object' || Array.isArray(aiOutput)) {
+  throw new Error('AI response JSON must be an object');
+}
+
+const { summary, changes } = validateAiOutput(aiOutput);
+const outputPaths = await writeGeneratedFiles(changes);
+
+const attemptLabelName = `${ATTEMPT_LABEL_PREFIX}${nextAttempt}`;
+const createLabelRes = await ghFetch(`/repos/${owner}/${repo}/labels`, {
+  method: 'POST',
+  body: JSON.stringify({
+    name: attemptLabelName,
+    color: 'fbca04',
+    description: `Auto-fix iteration ${nextAttempt}`,
+  }),
+});
+if (!createLabelRes.ok && createLabelRes.status !== 422) {
+  logError(`Auto-fix label create failed: ${createLabelRes.status}`, { attemptLabelName });
+}
+
+const applyLabelRes = await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/labels`, {
+  method: 'POST',
+  body: JSON.stringify({ labels: [attemptLabelName] }),
+});
+if (!applyLabelRes.ok) {
+  logError(`Auto-fix label apply failed: ${applyLabelRes.status}`, { attemptLabelName });
+}
+
+if (process.env.GITHUB_OUTPUT) {
+  await fsPromises.appendFile(
+    process.env.GITHUB_OUTPUT,
+    `fixed_paths<<EOF\n${outputPaths.join('\n')}\nEOF\nattempt_number=${nextAttempt}\nsummary<<EOF\n${summary}\nEOF\n`,
+    'utf8',
+  );
+}
+
+log('Auto-fix complete', { prNumber, attempt: nextAttempt, paths: outputPaths.join(', ') });

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -23,6 +23,7 @@ export const ANTHROPIC_MODEL_DEFAULTS = {
   validation: 'claude-opus-4-7',
   generation: 'claude-opus-4-7',
   review: 'claude-opus-4-7',
+  autofix: 'claude-opus-4-7',
 };
 
 export function requireEnv(name) {

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -108,7 +108,7 @@ const HEADING = '## 🔍 Automated Code Review';
 const review = rawReview.trim();
 const body = review.includes(HEADING) ? review : `${HEADING}\n\n${review}`;
 
-const verdictMatch = rawReview.match(/verdict(?::\s*|\s*\n+\s*)(APPROVED|REQUEST_CHANGES)/i);
+const verdictMatch = rawReview.match(/verdict(?::\s*|\s*\n+\s*)\**(APPROVED|REQUEST_CHANGES)/i);
 const isApproved = verdictMatch?.[1]?.toUpperCase() === 'APPROVED';
 
 const commentsRes = await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`);

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -130,10 +130,14 @@ if (!postRes.ok) throw new Error(`Comment upsert failed: ${postRes.status} ${awa
 
 log(`PR review comment ${existing ? 'updated' : 'posted'}`, { prNumber });
 
+const shortReviewBody = isApproved
+  ? 'Automated review passed. See the review comment for details.'
+  : 'Changes required. See the automated review comment above for details.';
+
 const reviewRes = await ghFetch(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
   method: 'POST',
   body: JSON.stringify({
-    body,
+    body: shortReviewBody,
     event: isApproved ? 'APPROVE' : 'REQUEST_CHANGES',
   }),
 });

--- a/scripts/tests/auto_fix_pr.test.mjs
+++ b/scripts/tests/auto_fix_pr.test.mjs
@@ -1,0 +1,324 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import http from 'node:http';
+
+const SCRIPTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PR_NUMBER = 55;
+const REVIEW_ID = 42;
+
+function startMockServer(handler) {
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    let rawBody = '';
+    req.on('data', (d) => (rawBody += d));
+    req.on('end', () => {
+      requests.push({ method: req.method, url: req.url, body: rawBody });
+      handler(req, res);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      server.requests = requests;
+      resolve(server);
+    });
+  });
+}
+
+function anthropicJson(text) {
+  return JSON.stringify({ content: [{ type: 'text', text }] });
+}
+
+function validLLMJson(filePath = 'fix-output.txt') {
+  return anthropicJson(
+    JSON.stringify({
+      summary: 'Fixed the reported issue',
+      changes: [{ target_path: filePath, file_content: 'fixed content' }],
+    }),
+  );
+}
+
+function makeHandler({
+  labelsStatus = 200,
+  labelsBody = '[]',
+  inlineCommentsStatus = 200,
+  inlineCommentsBody = '[]',
+  diffStatus = 200,
+  diffBody = '--- a/foo.js\n+++ b/foo.js\n@@ -1 +1 @@\n+added line\n',
+  llmResponse = null,
+  labelCreateStatus = 201,
+  applyLabelStatus = 200,
+  postCommentStatus = 201,
+} = {}) {
+  return (req, res) => {
+    const { method, url } = req;
+
+    if (url === '/v1/messages') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(llmResponse ?? validLLMJson());
+    }
+
+    if (method === 'GET' && /\/issues\/\d+\/labels$/.test(url)) {
+      res.writeHead(labelsStatus, { 'Content-Type': 'application/json' });
+      return res.end(labelsStatus < 300 ? labelsBody : 'Internal Server Error');
+    }
+
+    if (method === 'GET' && /\/reviews\/\d+\/comments$/.test(url)) {
+      res.writeHead(inlineCommentsStatus, { 'Content-Type': 'application/json' });
+      return res.end(inlineCommentsStatus < 300 ? inlineCommentsBody : 'error');
+    }
+
+    if (method === 'GET' && /\/pulls\/\d+$/.test(url)) {
+      res.writeHead(diffStatus);
+      return res.end(diffStatus < 300 ? diffBody : 'Forbidden');
+    }
+
+    if (method === 'POST' && /\/issues\/\d+\/comments$/.test(url)) {
+      res.writeHead(postCommentStatus, { 'Content-Type': 'application/json' });
+      return res.end(postCommentStatus < 300 ? '{"id":1}' : 'error');
+    }
+
+    if (method === 'POST' && /\/repos\/[^/]+\/[^/]+\/labels$/.test(url)) {
+      res.writeHead(labelCreateStatus, { 'Content-Type': 'application/json' });
+      return res.end(labelCreateStatus < 300 ? '{"id":1}' : 'error');
+    }
+
+    if (method === 'POST' && /\/issues\/\d+\/labels$/.test(url)) {
+      res.writeHead(applyLabelStatus, { 'Content-Type': 'application/json' });
+      return res.end(applyLabelStatus < 300 ? '[]' : 'error');
+    }
+
+    res.writeHead(404);
+    res.end('not found');
+  };
+}
+
+async function writeEventFile(prNumber = PR_NUMBER, reviewId = REVIEW_ID) {
+  const tmpFile = path.join(os.tmpdir(), `auto-fix-evt-${Date.now()}-${Math.random()}.json`);
+  await fs.writeFile(
+    tmpFile,
+    JSON.stringify({
+      pull_request: { number: prNumber },
+      review: { id: reviewId, body: 'Fix the bug on line 5.', state: 'changes_requested' },
+    }),
+  );
+  return tmpFile;
+}
+
+async function runAutoFix(port, eventFile, { extraEnv = {}, cwd = null } = {}) {
+  const env = {
+    PATH: process.env.PATH,
+    GITHUB_TOKEN: 'test-token',
+    ANTHROPIC_API_KEY: 'test-key',
+    GITHUB_REPOSITORY: 'owner/repo',
+    GITHUB_EVENT_PATH: eventFile,
+    GITHUB_API_URL: `http://127.0.0.1:${port}`,
+    ANTHROPIC_API_URL: `http://127.0.0.1:${port}/v1/messages`,
+    ...extraEnv,
+  };
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [path.join(SCRIPTS_DIR, 'auto_fix_pr.mjs')], {
+      env,
+      cwd: cwd ?? process.cwd(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => (stdout += d));
+    child.stderr.on('data', (d) => (stderr += d));
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test('auto_fix_pr exits 1 when label list fetch fails', async () => {
+  const server = await startMockServer(makeHandler({ labelsStatus: 500 }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /Label list failed/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('auto_fix_pr exits 0 and posts exhausted comment when max attempts reached', async () => {
+  const maxLabels = JSON.stringify([
+    { name: 'auto-fix-attempt-1' },
+    { name: 'auto-fix-attempt-2' },
+    { name: 'auto-fix-attempt-3' },
+  ]);
+  const server = await startMockServer(makeHandler({ labelsBody: maxLabels }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const comment = server.requests.find(
+      (r) => r.method === 'POST' && /\/issues\/\d+\/comments$/.test(r.url),
+    );
+    assert.ok(comment, 'expected a POST comment for exhausted state');
+    assert.match(JSON.parse(comment.body).body, /Auto-Fix Exhausted/);
+    assert.equal(
+      server.requests.filter((r) => r.url === '/v1/messages').length,
+      0,
+      'LLM should not be called when attempts exhausted',
+    );
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('auto_fix_pr exits 1 when diff fetch fails', async () => {
+  const server = await startMockServer(makeHandler({ diffStatus: 403 }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /Diff fetch failed/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('auto_fix_pr exits 1 when LLM returns invalid JSON', async () => {
+  const server = await startMockServer(
+    makeHandler({ llmResponse: anthropicJson('not json at all') }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+    assert.match(result.stderr + result.stdout, /not valid JSON/i);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('auto_fix_pr exits 1 when LLM returns JSON with no changes array', async () => {
+  const server = await startMockServer(
+    makeHandler({ llmResponse: anthropicJson(JSON.stringify({ summary: 'ok', changes: [] })) }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile);
+    assert.notEqual(result.code, 0);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('auto_fix_pr writes generated files and applies attempt-1 label on first run', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-run-'));
+  const server = await startMockServer(makeHandler({ llmResponse: validLLMJson('fixed.txt') }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile, { cwd: tmpDir });
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+    const written = await fs.readFile(path.join(tmpDir, 'fixed.txt'), 'utf8');
+    assert.equal(written, 'fixed content');
+
+    const labelApply = server.requests.find(
+      (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
+    );
+    assert.ok(labelApply, 'expected label apply request');
+    assert.ok(JSON.parse(labelApply.body).labels.includes('auto-fix-attempt-1'));
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+test('auto_fix_pr applies attempt-2 label when attempt-1 already exists', async () => {
+  const existingLabels = JSON.stringify([{ name: 'auto-fix-attempt-1' }]);
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-run-'));
+  const server = await startMockServer(
+    makeHandler({ labelsBody: existingLabels, llmResponse: validLLMJson('out.txt') }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile, { cwd: tmpDir });
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+    const labelApply = server.requests.find(
+      (r) => r.method === 'POST' && /\/issues\/\d+\/labels$/.test(r.url),
+    );
+    assert.ok(labelApply, 'expected label apply request');
+    assert.ok(JSON.parse(labelApply.body).labels.includes('auto-fix-attempt-2'));
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+test('auto_fix_pr includes inline review comments in LLM prompt', async () => {
+  const inlineComments = JSON.stringify([
+    { path: 'src/foo.js', original_line: 10, body: 'Rename this variable.' },
+  ]);
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-run-'));
+  const server = await startMockServer(
+    makeHandler({ inlineCommentsBody: inlineComments, llmResponse: validLLMJson('out.txt') }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile, { cwd: tmpDir });
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+    const llmCall = server.requests.find((r) => r.url === '/v1/messages');
+    assert.ok(llmCall, 'expected LLM call');
+    const userMsg = JSON.parse(llmCall.body).messages[0].content;
+    assert.match(userMsg, /src\/foo\.js/, 'inline comment file path should appear in prompt');
+    assert.match(userMsg, /Rename this variable/, 'inline comment body should appear in prompt');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+test('auto_fix_pr continues when inline comment fetch fails', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-run-'));
+  const server = await startMockServer(
+    makeHandler({ inlineCommentsStatus: 500, llmResponse: validLLMJson('out.txt') }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile, { cwd: tmpDir });
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
+test('auto_fix_pr creates attempt label in repo before applying it', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-run-'));
+  const server = await startMockServer(makeHandler({ llmResponse: validLLMJson('out.txt') }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile, { cwd: tmpDir });
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+    const labelCreate = server.requests.find(
+      (r) => r.method === 'POST' && /\/repos\/[^/]+\/[^/]+\/labels$/.test(r.url),
+    );
+    assert.ok(labelCreate, 'expected repo label create request');
+    assert.equal(JSON.parse(labelCreate.body).name, 'auto-fix-attempt-1');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});

--- a/scripts/tests/entrypoints.test.mjs
+++ b/scripts/tests/entrypoints.test.mjs
@@ -167,6 +167,82 @@ test('pr_review exits 1 when event has no pull_request.number', async () => {
   }
 });
 
+// auto_fix_pr.mjs
+
+test('auto_fix_pr exits 1 when GITHUB_TOKEN is missing', async () => {
+  assertFails(
+    await runScript('auto_fix_pr.mjs', {
+      ANTHROPIC_API_KEY: 'key',
+      GITHUB_REPOSITORY: 'owner/repo',
+      GITHUB_EVENT_PATH: '/tmp/event.json',
+    }),
+    /GITHUB_TOKEN/,
+  );
+});
+
+test('auto_fix_pr exits 1 when ANTHROPIC_API_KEY is missing', async () => {
+  assertFails(
+    await runScript('auto_fix_pr.mjs', {
+      GITHUB_TOKEN: 'token',
+      GITHUB_REPOSITORY: 'owner/repo',
+      GITHUB_EVENT_PATH: '/tmp/event.json',
+    }),
+    /ANTHROPIC_API_KEY/,
+  );
+});
+
+test('auto_fix_pr exits 1 when GITHUB_REPOSITORY is missing', async () => {
+  assertFails(
+    await runScript('auto_fix_pr.mjs', {
+      GITHUB_TOKEN: 'token',
+      ANTHROPIC_API_KEY: 'key',
+      GITHUB_EVENT_PATH: '/tmp/event.json',
+    }),
+    /GITHUB_REPOSITORY/,
+  );
+});
+
+test('auto_fix_pr exits 1 when GITHUB_EVENT_PATH is missing', async () => {
+  assertFails(
+    await runScript('auto_fix_pr.mjs', {
+      GITHUB_TOKEN: 'token',
+      ANTHROPIC_API_KEY: 'key',
+      GITHUB_REPOSITORY: 'owner/repo',
+    }),
+    /GITHUB_EVENT_PATH/,
+  );
+});
+
+test('auto_fix_pr exits 1 when event file does not exist', async () => {
+  assertFails(
+    await runScript('auto_fix_pr.mjs', {
+      GITHUB_TOKEN: 'token',
+      ANTHROPIC_API_KEY: 'key',
+      GITHUB_REPOSITORY: 'owner/repo',
+      GITHUB_EVENT_PATH: '/nonexistent/path/event.json',
+    }),
+    /event payload/i,
+  );
+});
+
+test('auto_fix_pr exits 1 when event has no pull_request.number', async () => {
+  const tmpFile = path.join(os.tmpdir(), `auto-fix-test-no-pr-${Date.now()}.json`);
+  await fs.writeFile(tmpFile, JSON.stringify({ action: 'submitted', review: { state: 'changes_requested' } }));
+  try {
+    assertFails(
+      await runScript('auto_fix_pr.mjs', {
+        GITHUB_TOKEN: 'token',
+        ANTHROPIC_API_KEY: 'key',
+        GITHUB_REPOSITORY: 'owner/repo',
+        GITHUB_EVENT_PATH: tmpFile,
+      }),
+      /pull_request\.number/,
+    );
+  } finally {
+    await fs.unlink(tmpFile).catch(() => {});
+  }
+});
+
 // upsert_issue_validation_comment.mjs
 
 test('upsert_issue_validation_comment exits 1 when ISSUE_NUMBER is missing', async () => {

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -405,6 +405,32 @@ test('pr_review applies changes-requested label on REQUEST_CHANGES verdict', asy
   }
 });
 
+test('pr_review sends short body to review endpoint, not the full comment body', async () => {
+  const server = await startMockServer(
+    makeHandler({ groqContent: 'Detailed review.\n\nVerdict: APPROVED' }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    const comment = server.requests.find(
+      (r) => (r.method === 'POST' || r.method === 'PATCH') && r.url.includes('/comments'),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.ok(comment, 'expected a comment upsert');
+    const reviewBody = JSON.parse(review.body).body;
+    const commentBody = JSON.parse(comment.body).body;
+    assert.notEqual(reviewBody, commentBody, 'review body should differ from comment body');
+    assert.ok(!reviewBody.includes(HEADING), 'review body should not contain the full heading');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
 test('pr_review falls back to PATCH when label POST returns 422', async () => {
   const server = await startMockServer(
     makeHandler({ groqContent: 'Verdict: APPROVED', labelCreateStatus: 422 }),

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -321,6 +321,78 @@ test('pr_review detects APPROVE when verdict is a markdown heading with value on
   }
 });
 
+test('pr_review detects APPROVE when verdict is bold markdown (**APPROVED**)', async () => {
+  const groqContent = '### 🚀 Verdict\n**APPROVED**';
+  const server = await startMockServer(makeHandler({ groqContent }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.equal(JSON.parse(review.body).event, 'APPROVE');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review detects REQUEST_CHANGES when verdict is bold markdown (**REQUEST_CHANGES**)', async () => {
+  const groqContent = '### 🚀 Verdict\n**REQUEST_CHANGES**';
+  const server = await startMockServer(makeHandler({ groqContent }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.equal(JSON.parse(review.body).event, 'REQUEST_CHANGES');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review detects APPROVE when verdict uses single asterisk (*APPROVED*)', async () => {
+  const groqContent = 'Summary: looks fine.\n\nVerdict: *APPROVED*';
+  const server = await startMockServer(makeHandler({ groqContent }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.equal(JSON.parse(review.body).event, 'APPROVE');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review defaults to REQUEST_CHANGES when verdict line echoes template placeholder', async () => {
+  const groqContent = '### 🚀 Verdict\n(APPROVED | REQUEST_CHANGES)';
+  const server = await startMockServer(makeHandler({ groqContent }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    const review = server.requests.find(
+      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    );
+    assert.ok(review, 'expected POST to reviews endpoint');
+    assert.equal(JSON.parse(review.body).event, 'REQUEST_CHANGES');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
 test('pr_review prepends heading when LLM response does not include it', async () => {
   const server = await startMockServer(makeHandler({ groqContent: 'Plain review text.' }));
   const eventFile = await writeEventFile();

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -327,11 +327,11 @@ test('pr_review prepends heading when LLM response does not include it', async (
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    const review = server.requests.find(
-      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    const comment = server.requests.find(
+      (r) => (r.method === 'POST' || r.method === 'PATCH') && r.url.includes('/comments'),
     );
-    assert.ok(review, 'expected POST to reviews endpoint');
-    const { body } = JSON.parse(review.body);
+    assert.ok(comment, 'expected a comment upsert request');
+    const { body } = JSON.parse(comment.body);
     assert.ok(body.startsWith(HEADING), `expected body to start with heading, got: ${body.slice(0, 80)}`);
   } finally {
     server.close();
@@ -346,11 +346,11 @@ test('pr_review does not duplicate heading when LLM response already contains it
   try {
     const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    const review = server.requests.find(
-      (r) => r.method === 'POST' && /\/pulls\/\d+\/reviews$/.test(r.url),
+    const comment = server.requests.find(
+      (r) => (r.method === 'POST' || r.method === 'PATCH') && r.url.includes('/comments'),
     );
-    assert.ok(review, 'expected POST to reviews endpoint');
-    const { body } = JSON.parse(review.body);
+    assert.ok(comment, 'expected a comment upsert request');
+    const { body } = JSON.parse(comment.body);
     const occurrences = body.split(HEADING).length - 1;
     assert.equal(occurrences, 1, `heading should appear exactly once, found ${occurrences} times`);
   } finally {

--- a/scripts/tests/prompts.test.mjs
+++ b/scripts/tests/prompts.test.mjs
@@ -9,6 +9,8 @@ const PROMPT_NAMES = [
   'generation-user',
   'pr-review-system',
   'pr-review-user',
+  'auto-fix-system',
+  'auto-fix-user',
 ];
 
 // ---------------------------------------------------------------------------
@@ -124,5 +126,33 @@ describe('prompt file contents', () => {
     const content = loadPrompt('pr-review-user');
     assert.ok(content.includes('Summary'));
     assert.ok(content.includes('Verdict'));
+  });
+
+  test('auto-fix-system mentions the required JSON output keys', () => {
+    const content = loadPrompt('auto-fix-system');
+    assert.ok(content.includes('summary'));
+    assert.ok(content.includes('changes'));
+    assert.ok(content.includes('target_path'));
+    assert.ok(content.includes('file_content'));
+  });
+
+  test('auto-fix-system constrains scope to issues explicitly in the review', () => {
+    const content = loadPrompt('auto-fix-system');
+    assert.ok(content.includes('explicit'));
+  });
+
+  test('auto-fix-user contains {{reviewFeedback}}, {{diff}}, and {{fileContents}} placeholders', () => {
+    const content = loadPrompt('auto-fix-user');
+    assert.ok(content.includes('{{reviewFeedback}}'));
+    assert.ok(content.includes('{{diff}}'));
+    assert.ok(content.includes('{{fileContents}}'));
+  });
+
+  test('auto-fix-user contains the JSON output schema', () => {
+    const content = loadPrompt('auto-fix-user');
+    assert.ok(content.includes('summary'));
+    assert.ok(content.includes('changes'));
+    assert.ok(content.includes('target_path'));
+    assert.ok(content.includes('file_content'));
   });
 });


### PR DESCRIPTION
- Add .github/workflows/auto-fix-pr.yml: triggers on pull_request_review
  with changes_requested, applies AI fixes and pushes to the PR branch,
  re-triggering the review loop (max 3 attempts via auto-fix-attempt-N labels)
- Add scripts/auto_fix_pr.mjs: fetches review feedback + inline comments,
  reads changed files, calls LLM for targeted fixes, writes results and
  tracks iteration via PR labels
- Add prompts/auto-fix-system.md and prompts/auto-fix-user.md for the fix stage
- Fix duplicate comment in pr_review.mjs: PR review submission now uses a
  short redirect body instead of repeating the full review text
- Update pr_review.test.mjs: fix two tests that checked the review body
  to correctly assert on the issue comment body instead
- Add entrypoint tests for auto_fix_pr.mjs
- Register autofix stage in config/models.yaml and config/labels.yaml

https://claude.ai/code/session_01CRQGGzu8YCpcCBzHDKVMBW