### PR TITLE
Improve prompt safety and determinism for generation and validation

### DIFF
--- a/prompts/generation-system.md
+++ b/prompts/generation-system.md
@@ -5,3 +5,9 @@ HARD LIMIT: changes must contain 1 to 6 objects — never more. This limit is ab
 Each object in changes must have target_path (a safe relative path) and file_content (the exact file contents to write).
 
 PRESERVATION RULE: You must preserve all existing file content unless the issue explicitly requests deletion or replacement. When modifying an existing file, incorporate your changes into the provided current content — do not rewrite from scratch. Additions and insertions only, unless removal is explicitly requested.
+
+SAFETY RULES:
+- Never output markdown fences, prose, or extra keys.
+- Never include absolute paths, path traversal (`..`), or shell commands as file content unless the issue explicitly asks for script changes.
+- Prefer updating an existing relevant file over creating a new one.
+- If the issue requests broad or ambiguous work, implement only the smallest deterministic subset that is directly supported by the issue text and provided file context.

--- a/prompts/generation-user.md
+++ b/prompts/generation-user.md
@@ -18,6 +18,8 @@ Requirements:
 5. Prefer focused, coherent changes over broad refactors.
 6. Generated code must be syntactically valid and consistent. No unresolved imports or references.
 7. Every path must be relative (no ../ and no absolute paths).
-8. Do not add explanations, comments, or metadata outside the required output.
+8. If a file is shown in the provided current content block and you modify it, preserve unchanged sections verbatim and apply minimal edits.
+9. If the issue requires information that is missing from the issue text or provided files, choose the safest minimal implementation and avoid inventing external APIs/contracts.
+10. Do not add explanations, comments, or metadata outside the required output.
 
 Output JSON only: { "summary": "One sentence summary of the generated change", "changes": [ { "target_path": "relative/path/to/file.ext", "file_content": "Exact content to write in the file" } ] }

--- a/prompts/validation-user.md
+++ b/prompts/validation-user.md
@@ -1,4 +1,5 @@
 Evaluate the following GitHub Issue for readiness to enter an automated coder agent pipeline.
+Return only the strict JSON object requested by the system prompt.
 
 ## Issue Title
 {{issueTitle}}


### PR DESCRIPTION
### Motivation
- Strengthen prompt guardrails so the automated code-generation agent produces small, safe, and deterministic JSON-only output and avoids unsafe paths or speculative edits when issue context is incomplete.

### Description
- Add explicit `SAFETY RULES` to `prompts/generation-system.md` forbidding markdown fences/prose/extra keys and unsafe paths, and preferring minimal, existing-file edits.
- Tighten `prompts/generation-user.md` by requiring preservation of unchanged sections when modifying shown files and instructing the agent to choose the safest minimal implementation rather than inventing external APIs or contracts.
- Clarify `prompts/validation-user.md` to require the agent to return only the strict JSON object requested by the system prompt.

### Testing
- Ran the repository test suite with `node --test scripts/tests/*.test.mjs`, and all tests passed (`256` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef57cfe9c88325afb1a309ee20a5a0)