### PR TITLE
fix(actions): prevent auto-fix workflow from being skipped unexpectedly

### DIFF
--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -2,7 +2,7 @@ name: Auto-Fix PR
 
 on:
   pull_request_review:
-    types: [submitted]
+    types: [submitted, edited, dismissed]
 
 permissions:
   contents: write
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   auto-fix:
-    if: github.event.review.state == 'changes_requested'
+    if: ${{ github.event.review.state == 'changes_requested' || github.event.review.state == 'CHANGES_REQUESTED' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -131,7 +131,7 @@ Node implementation:
 Required secret:
 - **Secret**: `GROQ_API_KEY` (or `ANTHROPIC_API_KEY`) — same provider selection rules apply (see above).
 
-The workflow triggers on `pull_request_review` events of type `submitted` where `review.state == 'changes_requested'`. This fires whether the reviewer is the automated review bot or a human.
+The workflow triggers on `pull_request_review` events (`submitted`, `edited`, `dismissed`) and only runs the auto-fix job when `review.state == 'changes_requested'` (case-insensitive match for compatibility). This fires whether the reviewer is the automated review bot or a human.
 
 On each run it:
 1. Checks the PR for `auto-fix-attempt-N` labels to determine how many auto-fix cycles have already run.


### PR DESCRIPTION
### Motivation
- The auto-fix job was frequently marked `skipped` in GitHub Actions due to event-type and payload-variant differences in `pull_request_review` events and review state casing.

### Description
- Broadened the workflow trigger in `.github/workflows/auto-fix-pr.yml` to listen for `pull_request_review` event types `submitted`, `edited`, and `dismissed` instead of only `submitted`.
- Hardened the job gate in `.github/workflows/auto-fix-pr.yml` to treat `review.state == 'changes_requested'` case-insensitively by accepting both `changes_requested` and `CHANGES_REQUESTED`.
- Updated `docs/code-generation.md` to document the expanded trigger behavior and the case-insensitive state check.
- Note: when applicable, PR descriptions should include `Closes #<issue_number>` per repository pipeline conventions.

### Testing
- Ran `node --test scripts/tests/*.test.mjs` and all automated tests passed (282 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efcecade0883258728b4ea1fcad643)