### PR TITLE
fix: handle markdown-fenced JSON in LLM responses

### DIFF
--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -7,7 +7,7 @@ import { requireEnv, loadLLMConfig } from './lib/config.mjs';
 import { callLLM } from './lib/llm_client.mjs';
 import { filterDiff, shouldIncludeFile } from './lib/file_filters.mjs';
 import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
-import { validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
+import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 
 const MAX_ATTEMPTS = 3;
@@ -170,7 +170,7 @@ const raw = await callLLM({
 
 let aiOutput;
 try {
-  aiOutput = JSON.parse(raw);
+  aiOutput = parseJsonResponse(raw);
 } catch {
   throw new Error('AI response was not valid JSON');
 }

--- a/scripts/generate_issue_change.mjs
+++ b/scripts/generate_issue_change.mjs
@@ -3,7 +3,7 @@
 import { buildDeterministicPrompt, loadConfigFromEnv } from './lib/config.mjs';
 import { callLLM } from './lib/llm_client.mjs';
 import { loadPrompt } from './lib/prompts.mjs';
-import { validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
+import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 import { buildFileContentsBlock } from './lib/file_injector.mjs';
 import fs from 'node:fs/promises';
@@ -26,7 +26,7 @@ async function main() {
 
   let aiOutput;
   try {
-    aiOutput = JSON.parse(raw);
+    aiOutput = parseJsonResponse(raw);
   } catch {
     throw new Error('AI response was not valid JSON');
   }

--- a/scripts/lib/output_writer.mjs
+++ b/scripts/lib/output_writer.mjs
@@ -2,6 +2,29 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const MAX_FILE_COUNT = 6;
+
+export function parseJsonResponse(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {}
+
+  const fenced = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  if (fenced) {
+    try {
+      return JSON.parse(fenced[1].trim());
+    } catch {}
+  }
+
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start !== -1 && end > start) {
+    try {
+      return JSON.parse(raw.slice(start, end + 1));
+    } catch {}
+  }
+
+  throw new Error('AI response was not valid JSON');
+}
 const MAX_FILE_CONTENT_LENGTH = 16000;
 
 function validateSingleChange(change, index) {

--- a/scripts/tests/output_writer.test.mjs
+++ b/scripts/tests/output_writer.test.mjs
@@ -3,7 +3,33 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { validateAiOutput, writeGeneratedFiles } from '../lib/output_writer.mjs';
+import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from '../lib/output_writer.mjs';
+
+// parseJsonResponse tests
+
+test('parseJsonResponse parses plain JSON', () => {
+  const result = parseJsonResponse('{"summary":"fix","changes":[]}');
+  assert.deepEqual(result, { summary: 'fix', changes: [] });
+});
+
+test('parseJsonResponse parses JSON wrapped in ```json fences', () => {
+  const result = parseJsonResponse('```json\n{"summary":"fix","changes":[]}\n```');
+  assert.deepEqual(result, { summary: 'fix', changes: [] });
+});
+
+test('parseJsonResponse parses JSON wrapped in plain ``` fences', () => {
+  const result = parseJsonResponse('```\n{"summary":"fix","changes":[]}\n```');
+  assert.deepEqual(result, { summary: 'fix', changes: [] });
+});
+
+test('parseJsonResponse extracts JSON when there is surrounding prose', () => {
+  const result = parseJsonResponse('Here is the output:\n{"summary":"fix","changes":[]}\nDone.');
+  assert.deepEqual(result, { summary: 'fix', changes: [] });
+});
+
+test('parseJsonResponse throws for completely non-JSON text', () => {
+  assert.throws(() => parseJsonResponse('not json at all'), /not valid JSON/);
+});
 
 test('validateAiOutput returns trimmed fields for valid input', () => {
   const result = validateAiOutput({


### PR DESCRIPTION
The Anthropic API does not support response_format, so the model
sometimes wraps its JSON output in markdown code fences, causing
JSON.parse to fail with 'AI response was not valid JSON'.

Adds parseJsonResponse() to output_writer.mjs that tries direct
JSON.parse, then extracts from fenced code blocks, then finds the
outermost {...} block before giving up. Both auto_fix_pr.mjs and
generate_issue_change.mjs now use it.

https://claude.ai/code/session_019ebpkdJptGWMgzFGBXCGDh