### PR TITLE
fix: enable Groq JSON mode for auto-fix and improve parse error logging

### DIFF
--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -165,14 +165,14 @@ const raw = await callLLM({
   model,
   apiUrl,
   temperature: 0.2,
-  responseFormat: null,
 });
 
 let aiOutput;
 try {
   aiOutput = parseJsonResponse(raw);
-} catch {
-  throw new Error('AI response was not valid JSON');
+} catch (parseErr) {
+  logError('AI response was not valid JSON', { preview: raw.slice(0, 500) });
+  throw new Error(`AI response was not valid JSON: ${parseErr.message}`);
 }
 if (!aiOutput || typeof aiOutput !== 'object' || Array.isArray(aiOutput)) {
   throw new Error('AI response JSON must be an object');

--- a/scripts/tests/auto_fix_pr.test.mjs
+++ b/scripts/tests/auto_fix_pr.test.mjs
@@ -246,6 +246,7 @@ test('auto_fix_pr falls back to automated review comment when review payload has
     }),
   );
   const eventFile = await writeEventFile();
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-fallback-'));
   const outputFile = path.join(os.tmpdir(), `autofix-output-${Date.now()}.txt`);
   try {
     const rawEvent = JSON.parse(await fs.readFile(eventFile, 'utf8'));
@@ -253,6 +254,7 @@ test('auto_fix_pr falls back to automated review comment when review payload has
     await fs.writeFile(eventFile, JSON.stringify(rawEvent));
 
     const result = await runAutoFix(server.address().port, eventFile, {
+      cwd: tmpDir,
       extraEnv: { GITHUB_OUTPUT: outputFile },
     });
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
@@ -261,6 +263,7 @@ test('auto_fix_pr falls back to automated review comment when review payload has
     server.close();
     await fs.unlink(eventFile).catch(() => {});
     await fs.unlink(outputFile).catch(() => {});
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 
@@ -277,12 +280,13 @@ test('auto_fix_pr paginates review comments to find latest automated review fall
     }),
   );
   const eventFile = await writeEventFile();
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-paged-'));
   try {
     const rawEvent = JSON.parse(await fs.readFile(eventFile, 'utf8'));
     rawEvent.review.body = '';
     await fs.writeFile(eventFile, JSON.stringify(rawEvent));
 
-    const result = await runAutoFix(server.address().port, eventFile);
+    const result = await runAutoFix(server.address().port, eventFile, { cwd: tmpDir });
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
     const commentRequests = server.requests.filter(
       (r) => r.method === 'GET' && /\/issues\/\d+\/comments\?/.test(r.url),
@@ -293,6 +297,7 @@ test('auto_fix_pr paginates review comments to find latest automated review fall
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
   }
 });
 


### PR DESCRIPTION
Passing responseFormat: null disabled Groq's json_object enforcement,
allowing the model to return non-JSON text that parseJsonResponse could
not recover. Removing the override restores the default JSON mode so the
API rejects non-JSON responses before they reach our parser.

Also captures the raw LLM output (first 500 chars) and the original
parse error in the thrown message to make future failures debuggable.

https://claude.ai/code/session_01PrmS6bbwWKQGt3KMLc7bxh