### PR TITLE
fix: pass max_tokens to Groq API to prevent JSON truncation in auto-fix

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -12,5 +12,5 @@ review:                 qwen/qwen3-32b
 review_temperature:     0.6
 
 autofix:                qwen/qwen3-32b
-autofix_temperature:    0
+autofix_temperature:    0.2
 autofix_max_tokens:     16384

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -13,3 +13,4 @@ review_temperature:     0.6
 
 autofix:                qwen/qwen3-32b
 autofix_temperature:    0
+autofix_max_tokens:     16384

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -165,6 +165,7 @@ const raw = await callLLM({
   model,
   apiUrl,
   temperature: 0.2,
+  maxTokens: 16384,
 });
 
 let aiOutput;

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -17,7 +17,7 @@ const ATTEMPT_LABEL_PREFIX = 'auto-fix-attempt-';
 const githubToken = requireEnv('GITHUB_TOKEN');
 const repository = requireEnv('GITHUB_REPOSITORY');
 const eventPath = requireEnv('GITHUB_EVENT_PATH');
-const { apiKey: llmApiKey, model, apiUrl, maxTokens: llmMaxTokens } = loadLLMConfig('autofix');
+const { apiKey: llmApiKey, model, apiUrl, temperature: llmTemperature, maxTokens: llmMaxTokens } = loadLLMConfig('autofix');
 
 let event;
 try {
@@ -164,7 +164,7 @@ const raw = await callLLM({
   apiKey: llmApiKey,
   model,
   apiUrl,
-  temperature: 0.2,
+  temperature: llmTemperature,
   maxTokens: llmMaxTokens,
 });
 

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -17,7 +17,7 @@ const ATTEMPT_LABEL_PREFIX = 'auto-fix-attempt-';
 const githubToken = requireEnv('GITHUB_TOKEN');
 const repository = requireEnv('GITHUB_REPOSITORY');
 const eventPath = requireEnv('GITHUB_EVENT_PATH');
-const { apiKey: llmApiKey, model, apiUrl } = loadLLMConfig('autofix');
+const { apiKey: llmApiKey, model, apiUrl, maxTokens: llmMaxTokens } = loadLLMConfig('autofix');
 
 let event;
 try {
@@ -165,7 +165,7 @@ const raw = await callLLM({
   model,
   apiUrl,
   temperature: 0.2,
-  maxTokens: 16384,
+  maxTokens: llmMaxTokens,
 });
 
 let aiOutput;

--- a/scripts/generate_issue_change.mjs
+++ b/scripts/generate_issue_change.mjs
@@ -22,6 +22,7 @@ async function main() {
     model: config.model,
     apiUrl: config.apiUrl,
     temperature: config.temperature,
+    maxTokens: config.maxTokens,
   });
 
   let aiOutput;

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -62,7 +62,15 @@ export function loadLLMConfig(stage = 'generation') {
       throw new Error(`Invalid temperature for stage "${stage}": ${rawTemp} (must be a number between 0 and 2)`);
     }
   }
-  return { provider, apiKey, model, apiUrl, temperature };
+  const rawMaxTokens = GROQ_MODEL_DEFAULTS[`${stage}_max_tokens`] ?? GROQ_MODEL_DEFAULTS.max_tokens;
+  let maxTokens;
+  if (rawMaxTokens !== undefined) {
+    maxTokens = parseInt(rawMaxTokens, 10);
+    if (isNaN(maxTokens) || maxTokens <= 0) {
+      throw new Error(`Invalid max_tokens for stage "${stage}": ${rawMaxTokens} (must be a positive integer)`);
+    }
+  }
+  return { provider, apiKey, model, apiUrl, temperature, maxTokens };
 }
 
 export function loadConfigFromEnv() {

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -78,7 +78,7 @@ export function loadConfigFromEnv() {
   const issueTitle = requireEnv('ISSUE_TITLE');
   const issueBody = (process.env.ISSUE_BODY || '').trim() || '(no body provided)';
 
-  const { apiKey, model, apiUrl, temperature } = loadLLMConfig('generation');
+  const { apiKey, model, apiUrl, temperature, maxTokens } = loadLLMConfig('generation');
 
   return {
     issueNumber,
@@ -88,6 +88,7 @@ export function loadConfigFromEnv() {
     model,
     apiUrl,
     temperature,
+    maxTokens,
   };
 }
 

--- a/scripts/lib/groq_client.mjs
+++ b/scripts/lib/groq_client.mjs
@@ -5,6 +5,7 @@ export async function callGroq({
   model,
   apiUrl,
   temperature = 0,
+  maxTokens,
   responseFormat = { type: 'json_object' },
 }) {
   const payload = {
@@ -15,6 +16,9 @@ export async function callGroq({
       { role: 'user', content: prompt },
     ],
   };
+  if (maxTokens != null) {
+    payload.max_tokens = maxTokens;
+  }
   if (responseFormat) {
     payload.response_format = responseFormat;
   }

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -10,7 +10,7 @@ import { log, error as logError } from './lib/logger.mjs';
 const githubToken = requireEnv('GITHUB_TOKEN');
 const repository = requireEnv('GITHUB_REPOSITORY');
 const eventPath = requireEnv('GITHUB_EVENT_PATH');
-const { apiKey: llmApiKey, model, apiUrl, temperature } = loadLLMConfig('review');
+const { apiKey: llmApiKey, model, apiUrl, temperature, maxTokens: llmMaxTokens } = loadLLMConfig('review');
 
 let event;
 try {
@@ -142,6 +142,7 @@ const rawReview = await callLLM({
   model,
   apiUrl,
   temperature,
+  maxTokens: llmMaxTokens,
   responseFormat: null,
 });
 

--- a/scripts/tests/groq_client.test.mjs
+++ b/scripts/tests/groq_client.test.mjs
@@ -97,3 +97,23 @@ test('callGroq includes response_format by default', async () => {
   await callGroq(BASE_ARGS);
   assert.deepEqual(capturedBody.response_format, { type: 'json_object' });
 });
+
+test('callGroq sends max_tokens when maxTokens is provided', async () => {
+  let capturedBody;
+  globalThis.fetch = async (_url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return makeResponse({ choices: [{ message: { content: '{}' } }] });
+  };
+  await callGroq({ ...BASE_ARGS, maxTokens: 16384 });
+  assert.equal(capturedBody.max_tokens, 16384);
+});
+
+test('callGroq omits max_tokens when maxTokens is not provided', async () => {
+  let capturedBody;
+  globalThis.fetch = async (_url, opts) => {
+    capturedBody = JSON.parse(opts.body);
+    return makeResponse({ choices: [{ message: { content: '{}' } }] });
+  };
+  await callGroq(BASE_ARGS);
+  assert.equal('max_tokens' in capturedBody, false);
+});

--- a/scripts/validate_issue.mjs
+++ b/scripts/validate_issue.mjs
@@ -10,12 +10,12 @@ async function main() {
   const issueNumber = requireEnv('ISSUE_NUMBER');
   const issueTitle = requireEnv('ISSUE_TITLE');
   const issueBody = (process.env.ISSUE_BODY || '').trim() || '(no body provided)';
-  const { apiKey, model, apiUrl, temperature } = loadLLMConfig('validation');
+  const { apiKey, model, apiUrl, temperature, maxTokens } = loadLLMConfig('validation');
 
   log('Validating issue', { issueNumber, issueTitle, model });
 
   const boundCallGroq = ({ prompt }) =>
-    callLLM({ prompt, systemPrompt: VALIDATION_SYSTEM_PROMPT, apiKey, model, apiUrl, temperature });
+    callLLM({ prompt, systemPrompt: VALIDATION_SYSTEM_PROMPT, apiKey, model, apiUrl, temperature, maxTokens });
 
   const result = await validateIssue({ issueTitle, issueBody, callGroq: boundCallGroq });
   const comment = formatGitHubComment(result, issueTitle);


### PR DESCRIPTION
The auto-fix pipeline was failing with a Groq 400 error because the model
hit its default completion token cap before finishing the JSON response.
Add maxTokens support to callGroq and set 16384 tokens for the auto-fix
call, which must output complete file contents in a single JSON document.

https://claude.ai/code/session_01Lhmi6GJpjS1ZjSUZcUrLeg