### PR TITLE
fix: reduce Groq request size to stay within 6000 TPM limit

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -13,4 +13,4 @@ review_temperature:     0.6
 
 autofix:                qwen/qwen3-32b
 autofix_temperature:    0.2
-autofix_max_tokens:     16384
+autofix_max_tokens:     4096

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -13,14 +13,21 @@ import { log, error as logError } from './lib/logger.mjs';
 const MAX_ATTEMPTS = 3;
 const MAX_FILE_SIZE = 2000;
 const MAX_FILES = 5;
-const MAX_DIFF_CHARS = 3000;
-const MAX_FEEDBACK_CHARS = 1500;
 const ATTEMPT_LABEL_PREFIX = 'auto-fix-attempt-';
+
+const MODEL_TPM = {
+  'qwen/qwen3-32b': 6000,
+  'llama-3.1-8b-instant': 30000,
+};
+
+function estimateTokens(text) {
+  return Math.ceil(text.length / 4);
+}
 
 const githubToken = requireEnv('GITHUB_TOKEN');
 const repository = requireEnv('GITHUB_REPOSITORY');
 const eventPath = requireEnv('GITHUB_EVENT_PATH');
-const { apiKey: llmApiKey, model, apiUrl, temperature: llmTemperature, maxTokens: llmMaxTokens } = loadLLMConfig('autofix');
+const { provider: llmProvider, apiKey: llmApiKey, model, apiUrl, temperature: llmTemperature, maxTokens: llmMaxTokens } = loadLLMConfig('autofix');
 
 let event;
 try {
@@ -121,16 +128,24 @@ if (!feedbackParts.length) {
   }
 }
 
+const systemPrompt = loadPrompt('auto-fix-system');
+const systemTokens = estimateTokens(systemPrompt);
+const tpmLimit = llmProvider === 'groq' ? (MODEL_TPM[model] ?? 6000) : 8000;
+const effectiveMaxTokens = Math.min(llmMaxTokens ?? 4096, tpmLimit - systemTokens - 200);
+const remaining = Math.max(0, tpmLimit - 200 - systemTokens - effectiveMaxTokens);
+const diffBudget = Math.floor(remaining * 0.6);
+const feedbackBudget = remaining - diffBudget;
+
 const reviewFeedback = (
   feedbackParts.join('\n\n---\n\n') || '(No specific review feedback provided)'
-).slice(0, MAX_FEEDBACK_CHARS);
+).slice(0, feedbackBudget * 4);
 
 const diffRes = await ghFetch(`/repos/${owner}/${repo}/pulls/${prNumber}`, {
   headers: { Accept: 'application/vnd.github.v3.diff' },
 });
 if (!diffRes.ok) throw new Error(`Diff fetch failed: ${diffRes.status}`);
 const rawDiff = await diffRes.text();
-const diff = filterDiff(rawDiff, MAX_DIFF_CHARS);
+const diff = filterDiff(rawDiff, diffBudget * 4);
 
 const changedFiles = [
   ...new Set([...rawDiff.matchAll(/^diff --git a\/(.*?) b\//gm)].map((m) => m[1])),
@@ -155,11 +170,19 @@ const fileContents =
     ? fileContentParts.join('\n\n')
     : 'No existing files identified as relevant to this review.';
 
-const systemPrompt = loadPrompt('auto-fix-system');
 const userPrompt = interpolatePrompt(loadPrompt('auto-fix-user'), {
   reviewFeedback,
   diff,
   fileContents,
+});
+
+log('token_estimate', {
+  system: systemTokens,
+  diff: estimateTokens(diff),
+  feedback: estimateTokens(reviewFeedback),
+  files: estimateTokens(fileContents),
+  max_tokens: effectiveMaxTokens,
+  total: systemTokens + estimateTokens(diff) + estimateTokens(reviewFeedback) + estimateTokens(fileContents) + effectiveMaxTokens,
 });
 
 const raw = await callLLM({
@@ -169,7 +192,7 @@ const raw = await callLLM({
   model,
   apiUrl,
   temperature: llmTemperature,
-  maxTokens: llmMaxTokens,
+  maxTokens: effectiveMaxTokens,
 });
 
 let aiOutput;

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -11,7 +11,10 @@ import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/
 import { log, error as logError } from './lib/logger.mjs';
 
 const MAX_ATTEMPTS = 3;
-const MAX_FILE_SIZE = 8000;
+const MAX_FILE_SIZE = 2000;
+const MAX_FILES = 5;
+const MAX_DIFF_CHARS = 3000;
+const MAX_FEEDBACK_CHARS = 1500;
 const ATTEMPT_LABEL_PREFIX = 'auto-fix-attempt-';
 
 const githubToken = requireEnv('GITHUB_TOKEN');
@@ -118,15 +121,16 @@ if (!feedbackParts.length) {
   }
 }
 
-const reviewFeedback =
-  feedbackParts.join('\n\n---\n\n') || '(No specific review feedback provided)';
+const reviewFeedback = (
+  feedbackParts.join('\n\n---\n\n') || '(No specific review feedback provided)'
+).slice(0, MAX_FEEDBACK_CHARS);
 
 const diffRes = await ghFetch(`/repos/${owner}/${repo}/pulls/${prNumber}`, {
   headers: { Accept: 'application/vnd.github.v3.diff' },
 });
 if (!diffRes.ok) throw new Error(`Diff fetch failed: ${diffRes.status}`);
 const rawDiff = await diffRes.text();
-const diff = filterDiff(rawDiff);
+const diff = filterDiff(rawDiff, MAX_DIFF_CHARS);
 
 const changedFiles = [
   ...new Set([...rawDiff.matchAll(/^diff --git a\/(.*?) b\//gm)].map((m) => m[1])),
@@ -134,7 +138,7 @@ const changedFiles = [
 
 const repoRoot = path.resolve(process.cwd());
 const fileContentParts = [];
-for (const filePath of changedFiles.slice(0, 10)) {
+for (const filePath of changedFiles.slice(0, MAX_FILES)) {
   const absPath = path.resolve(repoRoot, filePath);
   if (!absPath.startsWith(repoRoot + path.sep)) continue;
   try {

--- a/scripts/tests/auto_fix_pr.test.mjs
+++ b/scripts/tests/auto_fix_pr.test.mjs
@@ -388,6 +388,26 @@ test('auto_fix_pr continues when inline comment fetch fails', async () => {
   }
 });
 
+test('auto_fix_pr logs token_estimate before calling LLM', async () => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-tokens-'));
+  const server = await startMockServer(makeHandler({ llmResponse: validLLMJson('out.txt') }));
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runAutoFix(server.address().port, eventFile, { cwd: tmpDir });
+    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    assert.match(result.stdout, /token_estimate/);
+    const estimateLine = result.stdout.split('\n').find((l) => l.includes('token_estimate'));
+    const parsed = JSON.parse(estimateLine);
+    assert.ok(typeof parsed.system === 'number' && parsed.system > 0, 'system tokens > 0');
+    assert.ok(typeof parsed.total === 'number' && parsed.total > 0, 'total tokens > 0');
+    assert.ok(typeof parsed.max_tokens === 'number' && parsed.max_tokens > 0, 'max_tokens > 0');
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+    await fs.rm(tmpDir, { recursive: true }).catch(() => {});
+  }
+});
+
 test('auto_fix_pr creates attempt label in repo before applying it', async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-run-'));
   const server = await startMockServer(makeHandler({ llmResponse: validLLMJson('out.txt') }));


### PR DESCRIPTION
The autofix stage was requesting 17,560 tokens (1,176 prompt + 16,384
max_tokens), exceeding the Groq on-demand TPM limit of 6,000. Reduce
autofix_max_tokens from 16384 to 4096, and tighten input caps (diff,
file contents, feedback) so larger PRs also stay within budget.

https://claude.ai/code/session_01TJvcPobRTicdvVSmLySAWM