### PR TITLE
Add 429 retry-after logic to callGroq with configurable max retries

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -14,3 +14,5 @@ review_temperature:     0.6
 autofix:                qwen/qwen3-32b
 autofix_temperature:    0.2
 autofix_max_tokens:     4096
+
+groq_max_retries:       3

--- a/scripts/lib/groq_client.mjs
+++ b/scripts/lib/groq_client.mjs
@@ -1,3 +1,16 @@
+import { log } from './logger.mjs';
+
+function parseWaitMs(rawText, headers) {
+  const match = rawText.match(/Please try again in (\d+(?:\.\d+)?)s/i);
+  if (match) return Math.ceil(parseFloat(match[1]) * 1000);
+  const retryAfter = headers.get('Retry-After');
+  if (retryAfter != null) {
+    const secs = parseFloat(retryAfter);
+    if (!isNaN(secs) && secs >= 0) return Math.ceil(secs * 1000);
+  }
+  return null;
+}
+
 export async function callGroq({
   prompt,
   systemPrompt,
@@ -8,6 +21,9 @@ export async function callGroq({
   maxTokens,
   responseFormat = { type: 'json_object' },
 }) {
+  const parsed = parseInt(process.env.GROQ_MAX_RETRIES, 10);
+  const maxRetries = Number.isFinite(parsed) && parsed >= 0 ? parsed : 3;
+
   const payload = {
     model,
     temperature,
@@ -23,31 +39,46 @@ export async function callGroq({
     payload.response_format = responseFormat;
   }
 
-  const response = await fetch(apiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify(payload),
-  });
+  let lastError;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
 
-  const rawText = await response.text();
-  if (!response.ok) {
-    throw new Error(`Groq API HTTP error ${response.status}: ${rawText}`);
+    const rawText = await response.text();
+
+    if (response.status === 429) {
+      lastError = new Error(`Groq API HTTP error ${response.status}: ${rawText}`);
+      if (attempt === maxRetries) break;
+      const waitMs = parseWaitMs(rawText, response.headers) ?? 1000 * 2 ** attempt;
+      log('rate_limit_retry', { waitMs, attempt, model });
+      await new Promise((resolve) => setTimeout(resolve, waitMs));
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Groq API HTTP error ${response.status}: ${rawText}`);
+    }
+
+    let raw;
+    try {
+      raw = JSON.parse(rawText);
+    } catch {
+      throw new Error('Groq API returned non-JSON response');
+    }
+
+    const content = raw?.choices?.[0]?.message?.content;
+    if (!content || typeof content !== 'string') {
+      throw new Error('Unexpected Groq API response format');
+    }
+
+    return content;
   }
 
-  let raw;
-  try {
-    raw = JSON.parse(rawText);
-  } catch {
-    throw new Error('Groq API returned non-JSON response');
-  }
-
-  const content = raw?.choices?.[0]?.message?.content;
-  if (!content || typeof content !== 'string') {
-    throw new Error('Unexpected Groq API response format');
-  }
-
-  return content;
+  throw lastError;
 }


### PR DESCRIPTION
On rate-limit responses, parses wait time from the "Please try again in Xs"
body message, falls back to Retry-After header, then exponential backoff
(1s * 2^attempt). Max retries read from GROQ_MAX_RETRIES env var (default 3)
and documented in config/models.yaml as groq_max_retries. Logs each retry
attempt as structured JSON via the existing logger.

https://claude.ai/code/session_01LrQZsKdQDcaYB6NtJhHoeP