### PR TITLE
Harden workflow scripts: better error handling, parse diagnostics, and GitHub response handling

### DIFF
--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -10,6 +10,12 @@ import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
 import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 
+process.on('unhandledRejection', (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  logError('Unhandled promise rejection', { error: err.message, stack: err.stack });
+  process.exit(1);
+});
+
 const MAX_ATTEMPTS = 3;
 const MAX_FILE_SIZE = 2000;
 const MAX_FILES = 5;
@@ -33,7 +39,7 @@ let event;
 try {
   event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
 } catch (err) {
-  throw new Error(`Failed to parse GitHub event payload: ${err.message}`);
+  throw new Error(`Failed to parse GitHub event payload: ${err.message}`, { cause: err });
 }
 if (!event || typeof event !== 'object') throw new Error('GitHub event payload is not a valid object');
 
@@ -59,7 +65,7 @@ async function ghFetch(endpoint, options = {}) {
       headers: { ...githubHeaders, ...(options.headers || {}) },
     });
   } catch (err) {
-    throw new Error(`Network error calling GitHub API (${endpoint}): ${err.message}`);
+    throw new Error(`Network error calling GitHub API (${endpoint}): ${err.message}`, { cause: err });
   }
 }
 
@@ -112,11 +118,12 @@ if (reviewId) {
   const inlineRes = await ghFetch(
     `/repos/${owner}/${repo}/pulls/${prNumber}/reviews/${reviewId}/comments`,
   );
-  if (inlineRes.ok) {
-    const inlineComments = await inlineRes.json();
-    for (const c of inlineComments) {
-      feedbackParts.push(`**${c.path}** (line ${c.original_line || c.line || '?'}):\n${c.body}`);
-    }
+  if (!inlineRes.ok) {
+    throw new Error(`Review inline comments fetch failed: ${inlineRes.status}`);
+  }
+  const inlineComments = await inlineRes.json();
+  for (const c of inlineComments) {
+    feedbackParts.push(`**${c.path}** (line ${c.original_line || c.line || '?'}):\n${c.body}`);
   }
 }
 
@@ -200,7 +207,7 @@ try {
   aiOutput = parseJsonResponse(raw);
 } catch (parseErr) {
   logError('AI response was not valid JSON', { preview: raw.slice(0, 500) });
-  throw new Error(`AI response was not valid JSON: ${parseErr.message}`);
+  throw new Error(`AI response was not valid JSON: ${parseErr.message}`, { cause: parseErr });
 }
 if (!aiOutput || typeof aiOutput !== 'object' || Array.isArray(aiOutput)) {
   throw new Error('AI response JSON must be an object');
@@ -219,7 +226,7 @@ const createLabelRes = await ghFetch(`/repos/${owner}/${repo}/labels`, {
   }),
 });
 if (!createLabelRes.ok && createLabelRes.status !== 422) {
-  logError(`Auto-fix label create failed: ${createLabelRes.status}`, { attemptLabelName });
+  throw new Error(`Auto-fix label create failed: ${createLabelRes.status}`);
 }
 
 const applyLabelRes = await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/labels`, {
@@ -227,7 +234,7 @@ const applyLabelRes = await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/
   body: JSON.stringify({ labels: [attemptLabelName] }),
 });
 if (!applyLabelRes.ok) {
-  logError(`Auto-fix label apply failed: ${applyLabelRes.status}`, { attemptLabelName });
+  throw new Error(`Auto-fix label apply failed: ${applyLabelRes.status}`);
 }
 
 if (process.env.GITHUB_OUTPUT) {

--- a/scripts/generate_issue_change.mjs
+++ b/scripts/generate_issue_change.mjs
@@ -8,6 +8,12 @@ import { log, error as logError } from './lib/logger.mjs';
 import { buildFileContentsBlock } from './lib/file_injector.mjs';
 import fs from 'node:fs/promises';
 
+process.on('unhandledRejection', (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  logError('Unhandled promise rejection', { error: err.message, stack: err.stack });
+  process.exit(1);
+});
+
 async function main() {
   const config = loadConfigFromEnv();
   const fileContents = await buildFileContentsBlock(config.issueTitle, config.issueBody, process.cwd());
@@ -28,8 +34,8 @@ async function main() {
   let aiOutput;
   try {
     aiOutput = parseJsonResponse(raw);
-  } catch {
-    throw new Error('AI response was not valid JSON');
+  } catch (err) {
+    throw new Error('AI response was not valid JSON', { cause: err });
   }
   if (!aiOutput || typeof aiOutput !== 'object' || Array.isArray(aiOutput)) {
     throw new Error('AI response JSON must be an object');
@@ -51,6 +57,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  logError(err.message);
+  logError('Fatal error', { error: err.message, stack: err.stack });
   process.exit(1);
 });

--- a/scripts/lib/anthropic_client.mjs
+++ b/scripts/lib/anthropic_client.mjs
@@ -36,8 +36,8 @@ export async function callAnthropic({
   let raw;
   try {
     raw = JSON.parse(rawText);
-  } catch {
-    throw new Error('Anthropic API returned non-JSON response');
+  } catch (err) {
+    throw new Error('Anthropic API returned non-JSON response', { cause: err });
   }
 
   const content = raw?.content?.[0]?.text;

--- a/scripts/lib/file_injector.mjs
+++ b/scripts/lib/file_injector.mjs
@@ -44,8 +44,11 @@ export async function readRelevantFiles(candidates, repoRoot) {
       if (!stat.isFile()) continue;
       const raw = await fs.readFile(absPath, 'utf8');
       files.push({ path: candidate, content: raw.slice(0, MAX_FILE_SIZE) });
-    } catch {
-      // Non-existent or unreadable — skip silently.
+    } catch (err) {
+      // Ignore expected file-system misses; surface unexpected failures.
+      if (!['ENOENT', 'ENOTDIR', 'EACCES', 'EPERM', 'EISDIR'].includes(err?.code)) {
+        throw err;
+      }
     }
   }
 

--- a/scripts/lib/groq_client.mjs
+++ b/scripts/lib/groq_client.mjs
@@ -68,8 +68,8 @@ export async function callGroq({
     let raw;
     try {
       raw = JSON.parse(rawText);
-    } catch {
-      throw new Error('Groq API returned non-JSON response');
+    } catch (err) {
+      throw new Error('Groq API returned non-JSON response', { cause: err });
     }
 
     const content = raw?.choices?.[0]?.message?.content;

--- a/scripts/lib/issue_validator.mjs
+++ b/scripts/lib/issue_validator.mjs
@@ -45,8 +45,8 @@ export function parseGroqResponse(rawText) {
   let parsed;
   try {
     parsed = JSON.parse(rawText.slice(start, end + 1));
-  } catch {
-    throw new Error('Groq response contained invalid JSON');
+  } catch (err) {
+    throw new Error('Groq response contained invalid JSON', { cause: err });
   }
 
   if (typeof parsed.valid !== 'boolean') throw new Error('Response missing "valid" boolean');

--- a/scripts/lib/output_writer.mjs
+++ b/scripts/lib/output_writer.mjs
@@ -4,15 +4,20 @@ import path from 'node:path';
 const MAX_FILE_COUNT = 6;
 
 export function parseJsonResponse(raw) {
+  const parseErrors = [];
   try {
     return JSON.parse(raw);
-  } catch {}
+  } catch (err) {
+    parseErrors.push(`direct parse: ${err.message}`);
+  }
 
   const fenced = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
   if (fenced) {
     try {
       return JSON.parse(fenced[1].trim());
-    } catch {}
+    } catch (err) {
+      parseErrors.push(`fenced parse: ${err.message}`);
+    }
   }
 
   const start = raw.indexOf('{');
@@ -20,10 +25,12 @@ export function parseJsonResponse(raw) {
   if (start !== -1 && end > start) {
     try {
       return JSON.parse(raw.slice(start, end + 1));
-    } catch {}
+    } catch (err) {
+      parseErrors.push(`slice parse: ${err.message}`);
+    }
   }
 
-  throw new Error('AI response was not valid JSON');
+  throw new Error(`AI response was not valid JSON (${parseErrors.join('; ')})`);
 }
 const MAX_FILE_CONTENT_LENGTH = 16000;
 

--- a/scripts/manage_labels.mjs
+++ b/scripts/manage_labels.mjs
@@ -3,6 +3,12 @@
 import { requireEnv, loadLabelsConfig } from './lib/config.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 
+process.on('unhandledRejection', (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  logError('Unhandled promise rejection', { error: err.message, stack: err.stack });
+  process.exit(1);
+});
+
 const issueLabels = loadLabelsConfig('issue');
 const LABELS = [issueLabels.valid, issueLabels.invalid];
 
@@ -88,6 +94,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  logError(err.message);
+  logError('Fatal error', { error: err.message, stack: err.stack });
   process.exit(1);
 });

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -7,6 +7,12 @@ import { filterDiff } from './lib/file_filters.mjs';
 import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 
+process.on('unhandledRejection', (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  logError('Unhandled promise rejection', { error: err.message, stack: err.stack });
+  process.exit(1);
+});
+
 const githubToken = requireEnv('GITHUB_TOKEN');
 const repository = requireEnv('GITHUB_REPOSITORY');
 const eventPath = requireEnv('GITHUB_EVENT_PATH');
@@ -16,7 +22,7 @@ let event;
 try {
   event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
 } catch (err) {
-  throw new Error(`Failed to parse GitHub event payload: ${err.message}`);
+  throw new Error(`Failed to parse GitHub event payload: ${err.message}`, { cause: err });
 }
 if (!event || typeof event !== 'object') throw new Error('GitHub event payload is not a valid object');
 
@@ -54,7 +60,7 @@ async function ghFetch(path, options = {}) {
       headers: { ...githubHeaders, ...(options.headers || {}) },
     });
   } catch (err) {
-    throw new Error(`Network error calling GitHub API (${path}): ${err.message}`);
+    throw new Error(`Network error calling GitHub API (${path}): ${err.message}`, { cause: err });
   }
 }
 
@@ -176,6 +182,19 @@ const shortReviewBody = isApproved
   ? 'Automated review passed. See the review comment for details.'
   : 'Changes required. See the automated review comment above for details.';
 
+function isOwnPullRequestApprovalFailure(status, detail, approvedVerdict) {
+  if (!approvedVerdict || status !== 422) return false;
+  const ownPrApprovalPattern = /can not approve your own pull request/i;
+  if (ownPrApprovalPattern.test(detail)) return true;
+  try {
+    const parsed = JSON.parse(detail);
+    const errors = Array.isArray(parsed?.errors) ? parsed.errors.map(String) : [];
+    return errors.some((entry) => ownPrApprovalPattern.test(entry));
+  } catch {
+    return false;
+  }
+}
+
 const reviewRes = await ghFetch(`/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
   method: 'POST',
   body: JSON.stringify({
@@ -189,11 +208,16 @@ if (!reviewRes.ok) {
     reviewRes.status === 422 ||
     reviewRes.status === 403 ||
     (reviewRes.status === 401 && /permission|not permitted|resource not accessible/i.test(detail));
-  if (permissionLikeFailure) {
-    logError('PR review submit skipped: token lacks permission to submit reviews. Ensure "Pull requests: write" scope is granted and, if using GITHUB_TOKEN, enable "Allow GitHub Actions to create and approve pull requests" in repository Settings → Actions → General.', {
+  const ownPrApprovalFailure = isOwnPullRequestApprovalFailure(reviewRes.status, detail, isApproved);
+  if (ownPrApprovalFailure) {
+    logError('PR review submit skipped: GitHub rejected APPROVE because the actor opened the pull request. Continuing with review comment and labels.', {
       prNumber,
       status: reviewRes.status,
     });
+  } else if (permissionLikeFailure) {
+    throw new Error(
+      `Review submit failed due to permission/configuration issue: ${reviewRes.status} ${detail}`,
+    );
   } else {
     throw new Error(`Review submit failed: ${reviewRes.status} ${detail}`);
   }

--- a/scripts/tests/auto_fix_pr.test.mjs
+++ b/scripts/tests/auto_fix_pr.test.mjs
@@ -372,7 +372,7 @@ test('auto_fix_pr includes inline review comments in LLM prompt', async () => {
   }
 });
 
-test('auto_fix_pr continues when inline comment fetch fails', async () => {
+test('auto_fix_pr exits 1 when inline comment fetch fails', async () => {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-run-'));
   const server = await startMockServer(
     makeHandler({ inlineCommentsStatus: 500, llmResponse: validLLMJson('out.txt') }),
@@ -380,7 +380,8 @@ test('auto_fix_pr continues when inline comment fetch fails', async () => {
   const eventFile = await writeEventFile();
   try {
     const result = await runAutoFix(server.address().port, eventFile, { cwd: tmpDir });
-    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
+    assert.notEqual(result.code, 0, `expected non-zero exit, stderr: ${result.stderr}`);
+    assert.match(result.stderr + result.stdout, /Review inline comments fetch failed/);
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});

--- a/scripts/tests/file_injector.test.mjs
+++ b/scripts/tests/file_injector.test.mjs
@@ -107,6 +107,11 @@ describe('readRelevantFiles', () => {
     assert.equal(files.length, 0);
   });
 
+  test('skips ENOTDIR path-like tokens silently', async () => {
+    const files = await readRelevantFiles(['hello.js/section'], tmpDir);
+    assert.equal(files.length, 0);
+  });
+
   test('prevents traversal outside the repo root', async () => {
     const files = await readRelevantFiles(['../outside.js'], tmpDir);
     assert.equal(files.length, 0);

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -46,6 +46,7 @@ function makeHandler({
   commentsBody = '[]',
   upsertStatus = 201,
   reviewStatus = 201,
+  reviewBody = null,
   labelCreateStatus = 201,
   labelUpdateStatus = 200,
   applyLabelStatus = 200,
@@ -84,7 +85,7 @@ function makeHandler({
 
     if (method === 'POST' && /\/pulls\/\d+\/reviews$/.test(url)) {
       res.writeHead(reviewStatus, { 'Content-Type': 'application/json' });
-      return res.end(reviewStatus < 300 ? '{"id":1}' : 'Internal Server Error');
+      return res.end(reviewStatus < 300 ? '{"id":1}' : (reviewBody ?? 'Internal Server Error'));
     }
 
     if (
@@ -240,26 +241,49 @@ test('pr_review exits 1 when review submit returns non-2xx (not permission-relat
   }
 });
 
-test('pr_review logs warning and exits 0 when review submit returns 422 (permissions)', async () => {
+test('pr_review exits 1 when review submit returns 422 (permissions)', async () => {
   const server = await startMockServer(makeHandler({ reviewStatus: 422 }));
   const eventFile = await writeEventFile();
   try {
     const result = await runPrReview(server.address().port, eventFile);
-    assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    assert.match(result.stderr + result.stdout, /lacks permission/);
+    assert.notEqual(result.code, 0, `expected non-zero exit, stderr: ${result.stderr}`);
+    assert.match(result.stderr + result.stdout, /permission\/configuration issue/);
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});
   }
 });
 
-test('pr_review logs warning and exits 0 when review submit returns 403 (insufficient scope)', async () => {
+test('pr_review exits 1 when review submit returns 403 (insufficient scope)', async () => {
   const server = await startMockServer(makeHandler({ reviewStatus: 403 }));
   const eventFile = await writeEventFile();
   try {
     const result = await runPrReview(server.address().port, eventFile);
+    assert.notEqual(result.code, 0, `expected non-zero exit, stderr: ${result.stderr}`);
+    assert.match(result.stderr + result.stdout, /permission\/configuration issue/);
+  } finally {
+    server.close();
+    await fs.unlink(eventFile).catch(() => {});
+  }
+});
+
+test('pr_review continues when GitHub rejects APPROVE on own pull request', async () => {
+  const ownPrError = JSON.stringify({
+    message: 'Unprocessable Entity',
+    errors: ['Review Can not approve your own pull request'],
+  });
+  const server = await startMockServer(
+    makeHandler({
+      groqContent: 'Looks good.\n\nVerdict: APPROVED',
+      reviewStatus: 422,
+      reviewBody: ownPrError,
+    }),
+  );
+  const eventFile = await writeEventFile();
+  try {
+    const result = await runPrReview(server.address().port, eventFile);
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);
-    assert.match(result.stderr + result.stdout, /lacks permission/);
+    assert.match(result.stderr + result.stdout, /rejected APPROVE because the actor opened the pull request/i);
   } finally {
     server.close();
     await fs.unlink(eventFile).catch(() => {});

--- a/scripts/upsert_issue_validation_comment.mjs
+++ b/scripts/upsert_issue_validation_comment.mjs
@@ -3,6 +3,12 @@
 import { requireEnv } from './lib/config.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 
+process.on('unhandledRejection', (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  logError('Unhandled promise rejection', { error: err.message, stack: err.stack });
+  process.exit(1);
+});
+
 const COMMENT_MARKER = '<!-- issue-validation-report -->';
 
 function getHeaders(token) {
@@ -84,6 +90,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  logError(err.message);
+  logError('Fatal error', { error: err.message, stack: err.stack });
   process.exit(1);
 });

--- a/scripts/validate_issue.mjs
+++ b/scripts/validate_issue.mjs
@@ -6,6 +6,12 @@ import { requireEnv, loadLLMConfig } from './lib/config.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 import fs from 'node:fs/promises';
 
+process.on('unhandledRejection', (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  logError('Unhandled promise rejection', { error: err.message, stack: err.stack });
+  process.exit(1);
+});
+
 async function main() {
   const issueNumber = requireEnv('ISSUE_NUMBER');
   const issueTitle = requireEnv('ISSUE_TITLE');
@@ -37,6 +43,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  logError(err.message);
+  logError('Fatal error', { error: err.message, stack: err.stack });
   process.exit(1);
 });


### PR DESCRIPTION
### Motivation
- Improve robustness of various workflow helper scripts by surfacing unexpected failures and making error details easier to debug. 
- Make LLM JSON parsing more resilient and provide clearer diagnostics when models return non-JSON or fenced responses. 
- Handle GitHub API edge-cases (inline comment fetch failures and approvals on own PRs) explicitly instead of silently continuing.

### Description
- Added global `unhandledRejection` handlers across CLI scripts (`auto_fix_pr.mjs`, `generate_issue_change.mjs`, `manage_labels.mjs`, `pr_review.mjs`, `upsert_issue_validation_comment.mjs`, `validate_issue.mjs`) that log the error and exit with failure. 
- Wrapped thrown errors with `cause` in several parsing and network failure locations for more context (event JSON parse, GitHub fetch network errors, AI response parse errors, Anthropics/Groq JSON parses). 
- Tightened GitHub inline review comment fetching in `auto_fix_pr.mjs` to fail on non-OK responses instead of continuing silently. 
- Improved `pr_review.mjs` to detect and continue when GitHub rejects an `APPROVE` because the actor opened the PR, while surfacing other permission/configuration failures as errors. 
- Enhanced JSON parsing in `output_writer.mjs` to try multiple strategies (direct, fenced, slice) and include collected parse error messages in the final thrown error. 
- Made file reads in `file_injector.mjs` surface unexpected filesystem errors while continuing to silently skip common expected errors (like `ENOENT`, `ENOTDIR`, `EACCES`, `EPERM`, `EISDIR`). 
- Various tests updated to match new error semantics and added cases (updated `scripts/tests/auto_fix_pr.test.mjs`, `file_injector.test.mjs`, and `pr_review.test.mjs`).

### Testing
- Ran the updated test suite under `scripts/tests/` which includes `auto_fix_pr.test.mjs`, `file_injector.test.mjs`, and `pr_review.test.mjs`, and adjusted expectations for new failure modes; all tests passed locally. 
- Verified unit tests that exercise parsing fallbacks around `parseJsonResponse` and Groq/Anthropic clients to confirm clearer error messages and behavior changes. 
- Exercised PR-review flows with mocked GitHub responses to confirm the new handling for own-PR approve rejections and permission/configuration failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0159dfaac83259f91dc3056764090)