### PR TITLE
docs: clarify the issue-to-review automation loop

### DIFF
--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -87,6 +87,21 @@ All label names, colors, and descriptions are configurable in `config/labels.yam
    - body includes generated summary and `Closes #<number>`
    - changed files are limited to the generated AI target paths (maximum 6 files)
 
+## Loop: `issue -> issue review`
+
+The project now runs as a continuous loop rather than a one-shot generation:
+
+1. **Issue validation** (`validate-issue.yml`) reviews issue quality and applies `ready-for-dev` or `needs-refinement`.
+2. **Code generation** (`code-generation.yml`) starts only when `ready-for-dev` is applied and opens/updates a PR for that issue.
+3. **PR review** (`pr-review.yml`) runs on branch pushes, posts structured feedback, submits review status, and applies `review-approved` or `changes-requested`.
+4. **Auto-fix** (`auto-fix-pr.yml`) runs when `changes-requested` is applied, generates a targeted fix commit, and pushes it.
+5. The push from auto-fix re-triggers **PR review**, creating the iterative review loop.
+6. The loop ends when either:
+   - PR review returns `review-approved`, or
+   - auto-fix reaches 3 attempts and requests manual intervention.
+
+In practice, this means the issue is not only used to create the initial PR; it also drives the downstream review/fix cycles through labels and automated review signals.
+
 ## Limitations (MVP)
 
 - Triggers on `ready-for-dev` label application event.


### PR DESCRIPTION
### Motivation
- Make the end-to-end behavior explicit by showing that issue validation, PR generation, automated review, and label-driven auto-fix form an iterative loop rather than a one-shot PR creation step.

### Description
- Add a new "Loop: `issue -> issue review`" section to `docs/code-generation.md` that lists the step-by-step cycle (issue validation → code generation → PR review → auto-fix → re-review) and the loop termination conditions (`review-approved` or 3 auto-fix attempts), and keep the change documentation-only.

### Testing
- No automated tests were run because this is a documentation-only change and does not modify scripts or runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f159df54a4832598818b2c72f017cd)