### PR TITLE
docs: add documentation and ADR gap analysis

### DIFF
--- a/docs/documentation-gaps.md
+++ b/docs/documentation-gaps.md
@@ -1,0 +1,137 @@
+# Documentation Gap Analysis (including ADRs)
+
+Date: 2026-04-29
+
+## Scope reviewed
+
+- Product/process docs: `docs/mvp.md`, `docs/code-generation.md`, `docs/testing.md`
+- ADR index and records: `docs/adr/README.md`, `docs/adr/0001` → `0006`
+- Related implementation for traceability: workflow files under `.github/workflows/` and scripts under `scripts/`
+
+## Detected gaps
+
+### 1) Missing operator runbook for failure triage
+
+**Gap**
+The current documentation explains expected behavior and setup, but not a concise incident/runbook path for common failures (provider outage, token permission drift, label mismatch, empty generation output, auto-fix loop stop at attempt 3).
+
+**Impact**
+On-call maintainers may spend extra time diagnosing routine failures and may apply inconsistent manual recovery steps.
+
+**Recommendation**
+Add `docs/runbook.md` with:
+- Symptom → probable cause mapping
+- Exact GitHub checks/log locations
+- Recovery actions per workflow (`validate-issue`, `code-generation`, `pr-review`, `auto-fix-pr`)
+- Escalation criteria and manual override path
+
+---
+
+### 2) No architecture diagram for end-to-end control flow
+
+**Gap**
+The loop is described textually in `docs/code-generation.md`, but lacks a single visual sequence/state diagram connecting issue events, label transitions, workflow triggers, and stop conditions.
+
+**Impact**
+Harder onboarding and higher risk of misunderstanding trigger semantics (especially `labeled` event behavior and re-pulse logic).
+
+**Recommendation**
+Add a Mermaid sequence diagram in `docs/code-generation.md` (or `docs/architecture.md`) showing:
+- Issue lifecycle (`needs-refinement` ↔ `ready-for-dev`)
+- PR review verdict labels (`review-approved` / `changes-requested`)
+- Auto-fix attempts (`auto-fix-attempt-N`) and terminal conditions
+
+---
+
+### 3) ADR coverage gap for review-trigger choice
+
+**Gap**
+There is no dedicated ADR documenting why PR review is triggered on `push` to all branches instead of narrower PR-centric triggers (`pull_request` synchronize/opened), including trade-offs and operational safeguards.
+
+**Impact**
+Future contributors may “optimize” trigger behavior without understanding rationale, potentially breaking current branch→PR resolution assumptions.
+
+**Recommendation**
+Create a new ADR (e.g., `0007`) capturing:
+- Decision context
+- Considered alternatives
+- Chosen trigger and implications
+- Guardrails for no-PR branches
+
+---
+
+### 4) ADR coverage gap for provider strategy evolution
+
+**Gap**
+ADRs capture Anthropic/Groq and model defaults, but current workflows mostly wire `GROQ_API_KEY`. The docs discuss dual-provider behavior at length, yet operationally this can look asymmetric.
+
+**Impact**
+Potential confusion about “supported vs wired-by-default” provider posture and what must be configured per workflow today.
+
+**Recommendation**
+Either:
+1. Add/update ADR clarifying current provider posture per workflow stage; or
+2. Narrow docs to match implemented posture until full parity exists.
+
+Also add a matrix table by workflow: required env vars, optional vars, and fallback behavior.
+
+---
+
+### 5) Missing formal data contract docs for script outputs
+
+**Gap**
+Entrypoint scripts communicate via workflow outputs (e.g., `generated_paths`, `summary`, `fixed_paths`, `attempt_number`), but there is no explicit versioned contract documentation.
+
+**Impact**
+Refactors in scripts risk silently breaking workflow assumptions.
+
+**Recommendation**
+Add `docs/contracts.md` with per-script I/O contracts:
+- Required env vars
+- Output keys and semantics
+- Exit-code meaning
+- Failure modes
+
+---
+
+### 6) Testing documentation does not map tests to risk areas
+
+**Gap**
+`docs/testing.md` exists, but there is no traceability table linking test suites to workflow risks and critical user journeys.
+
+**Impact**
+Hard to assess coverage quality when changing automation logic.
+
+**Recommendation**
+Extend testing docs with a “risk→test mapping” table:
+- Label parsing/config regression
+- Output path safety
+- Review comment upsert behavior
+- Auto-fix attempt limit enforcement
+
+---
+
+### 7) Missing changelog policy for automation behavior changes
+
+**Gap**
+Major behavior shifts are partly reflected in ADRs, but there is no explicit contributor-facing rule for when to update docs + ADR + release/changelog notes together.
+
+**Impact**
+Documentation drift risk increases as workflows evolve.
+
+**Recommendation**
+Add a short documentation governance section (or `CONTRIBUTING.md` subsection) specifying minimum update set for behavior changes.
+
+## ADR-specific observations
+
+- ADR index is present and up to date through `0006`.
+- Records are focused and coherent, but a few operational decisions remain undocumented (notably PR review trigger scope and provider stage parity).
+- No superseded/deprecated ADR markers are currently needed, but a status field convention (`Accepted`, `Superseded`, `Deprecated`) would help future maintenance.
+
+## Suggested next actions (priority order)
+
+1. Add runbook (`docs/runbook.md`) for operational reliability.
+2. Add ADR-0007 for PR review trigger strategy.
+3. Add contracts documentation for script/workflow boundaries.
+4. Add architecture sequence diagram for onboarding clarity.
+5. Align provider narrative in docs with actual stage wiring.


### PR DESCRIPTION
### Motivation
- Provide a focused audit of documentation and ADR coverage for the AI issue→PR automation so maintainers have an actionable checklist to reduce operational risk and documentation drift.

### Description
- Add `docs/documentation-gaps.md` which summarizes the review scope, identifies seven concrete gaps (operator runbook, architecture diagram, ADR coverage for review trigger and provider strategy, script output contracts, test→risk mapping, and changelog/governance policy), records ADR observations, and lists prioritized next actions; committed under the message `docs: add documentation and ADR gap analysis`.

### Testing
- No code changes were made; file creation and content were validated by printing the file (`nl -ba docs/documentation-gaps.md | sed -n '1,220p'`) and the commit was confirmed with `git commit`/`git status`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15b671bdc83259257ac6c554d8e6a)