### PR TITLE
docs: add end-to-end Mermaid sequence diagram and close gap #2

### DIFF
--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -125,12 +125,12 @@ sequenceDiagram
 
     PR->>pr-review.yml: push event
     pr-review.yml-->>PR: post review comment
-    pr-review.yml-->>Issue: apply review-approved or changes-requested
+    pr-review.yml-->>PR: apply review-approved or changes-requested
 
     alt review-approved
         PR-->>User: ready for manual merge
     else changes-requested (attempt < 3)
-        Issue->>auto-fix-pr.yml: labeled changes-requested
+        PR->>auto-fix-pr.yml: pull_request labeled changes-requested
         auto-fix-pr.yml-->>PR: push fix commit + apply auto-fix-attempt-N
         PR->>pr-review.yml: push event (synchronize)
         Note over pr-review.yml,auto-fix-pr.yml: loop repeats up to 3 times

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -102,6 +102,43 @@ The project now runs as a continuous loop rather than a one-shot generation:
 
 In practice, this means the issue is not only used to create the initial PR; it also drives the downstream review/fix cycles through labels and automated review signals.
 
+## End-to-End Control Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Issue
+    participant validate-issue.yml
+    participant code-generation.yml
+    participant pr-review.yml
+    participant auto-fix-pr.yml
+    participant PR
+
+    User->>Issue: Create issue
+    Issue->>validate-issue.yml: issue opened/edited event
+    validate-issue.yml-->>Issue: apply needs-refinement
+    Note over Issue,validate-issue.yml: User refines issue
+    validate-issue.yml-->>Issue: apply ready-for-dev
+
+    Issue->>code-generation.yml: labeled ready-for-dev
+    code-generation.yml->>PR: open PR on ai/issue-N branch
+
+    PR->>pr-review.yml: push event
+    pr-review.yml-->>PR: post review comment
+    pr-review.yml-->>Issue: apply review-approved or changes-requested
+
+    alt review-approved
+        PR-->>User: ready for manual merge
+    else changes-requested (attempt < 3)
+        Issue->>auto-fix-pr.yml: labeled changes-requested
+        auto-fix-pr.yml-->>PR: push fix commit + apply auto-fix-attempt-N
+        PR->>pr-review.yml: push event (synchronize)
+        Note over pr-review.yml,auto-fix-pr.yml: loop repeats up to 3 times
+    else changes-requested (attempt = 3)
+        auto-fix-pr.yml-->>PR: post manual intervention comment
+    end
+```
+
 ## Limitations (MVP)
 
 - Triggers on `ready-for-dev` label application event.

--- a/docs/documentation-gaps.md
+++ b/docs/documentation-gaps.md
@@ -10,22 +10,6 @@ Date: 2026-04-29
 
 ## Detected gaps
 
-### 2) No architecture diagram for end-to-end control flow
-
-**Gap**
-The loop is described textually in `docs/code-generation.md`, but lacks a single visual sequence/state diagram connecting issue events, label transitions, workflow triggers, and stop conditions.
-
-**Impact**
-Harder onboarding and higher risk of misunderstanding trigger semantics (especially `labeled` event behavior and re-pulse logic).
-
-**Recommendation**
-Add a Mermaid sequence diagram in `docs/code-generation.md` (or `docs/architecture.md`) showing:
-- Issue lifecycle (`needs-refinement` ↔ `ready-for-dev`)
-- PR review verdict labels (`review-approved` / `changes-requested`)
-- Auto-fix attempts (`auto-fix-attempt-N`) and terminal conditions
-
----
-
 ### 3) ADR coverage gap for review-trigger choice
 
 **Gap**
@@ -113,5 +97,4 @@ Add a short documentation governance section (or `CONTRIBUTING.md` subsection) s
 
 ## Suggested next actions (priority order)
 
-1. Add architecture sequence diagram for onboarding clarity.
-2. Align provider narrative in docs with actual stage wiring.
+1. Align provider narrative in docs with actual stage wiring.


### PR DESCRIPTION
Add a Mermaid sequence diagram to docs/code-generation.md showing the
full issue → validation → code generation → PR review → auto-fix loop,
including label transitions and terminal conditions.

Remove gap #2 and its corresponding entry from the suggested next actions
in docs/documentation-gaps.md now that it is resolved.

https://claude.ai/code/session_017ED9hPmtkiY6c5NNggWbE5