### PR TITLE
docs: add Code Generation quick-start and revalidate documentation gaps

### DIFF
--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -2,6 +2,26 @@
 
 This repository includes an MVP workflow that converts validated issues into AI-generated draft pull requests. The default AI provider is **Anthropic** (Claude models). Groq is also supported and can be selected via the `AI_PROVIDER` environment variable. The workflow triggers automatically when the validation agent applies the `ready-for-dev` label.
 
+## Quick Start (Operator)
+
+For a first-time setup, complete these steps in order:
+
+1. Configure required secrets in **Settings → Secrets and variables → Actions**:
+   - `ANTHROPIC_API_KEY` and/or `GROQ_API_KEY`
+   - `AI_PR_TOKEN` (recommended for reliable PR/label/review writes)
+2. (Optional) Configure provider variables:
+   - `AI_PROVIDER`, `ANTHROPIC_MODEL`, `GROQ_MODEL`, `GROQ_API_URL`
+3. Confirm repository Actions permission strategy:
+   - either enable **Allow GitHub Actions to create and approve pull requests**
+   - or keep it disabled and rely on `AI_PR_TOKEN`
+4. Create/edit an issue and wait for `ready-for-dev`.
+5. Verify generated PR appears on branch `ai/issue-<number>`.
+6. Monitor review loop labels:
+   - `review-approved` ends the loop
+   - `changes-requested` triggers auto-fix (up to 3 attempts)
+
+If something fails, use `docs/runbook.md` symptom mapping and recovery actions first.
+
 ## Workflow Overview
 
 File: `.github/workflows/code-generation.yml`

--- a/docs/documentation-gaps.md
+++ b/docs/documentation-gaps.md
@@ -8,60 +8,48 @@ Date: 2026-04-29
 - ADR index and records: `docs/adr/README.md`, `docs/adr/0001` → `0007`
 - Related implementation for traceability: workflow files under `.github/workflows/` and scripts under `scripts/`
 
-## Detected gaps
+## Status legend
 
-### 1) ADR coverage gap for provider strategy evolution
+- **Closed**: addressed in current docs/ADRs.
+- **Open**: still recommended follow-up.
 
-**Gap**
-ADRs capture Anthropic/Groq and model defaults, but current workflows mostly wire `GROQ_API_KEY`. The docs discuss dual-provider behavior at length, yet operationally this can look asymmetric.
+## Gap status (revalidated)
 
-**Impact**
-Potential confusion about “supported vs wired-by-default” provider posture and what must be configured per workflow today.
+### 1) ADR coverage gap for provider strategy evolution — **Closed**
 
-**Recommendation**
-Either:
-1. Add/update ADR clarifying current provider posture per workflow stage; or
-2. Narrow docs to match implemented posture until full parity exists.
+**Revalidation**
+`docs/code-generation.md` now documents provider selection, defaults, and a per-workflow matrix for required/optional variables and fallback behavior.
 
-Also add a matrix table by workflow: required env vars, optional vars, and fallback behavior.
+**Evidence**
+- Provider behavior matrix and fallback are documented.
+- Per-workflow environment variable matrix is documented.
 
----
-
-### 2) Missing formal data contract docs for script outputs
-
-**Gap**
-Entrypoint scripts communicate via workflow outputs (e.g., `generated_paths`, `summary`, `fixed_paths`, `attempt_number`), but there is no explicit versioned contract documentation.
-
-**Impact**
-Refactors in scripts risk silently breaking workflow assumptions.
-
-**Recommendation**
-Add `docs/contracts.md` with per-script I/O contracts:
-- Required env vars
-- Output keys and semantics
-- Exit-code meaning
-- Failure modes
+**Disposition**
+No immediate doc action required unless provider strategy changes again.
 
 ---
 
-### 3) Testing documentation does not map tests to risk areas
+### 2) Missing formal data contract docs for script outputs — **Closed**
 
-**Gap**
-`docs/testing.md` exists, but there is no traceability table linking test suites to workflow risks and critical user journeys.
+**Revalidation**
+`docs/contracts.md` exists and documents script/workflow contracts, required inputs, outputs, and constraints.
 
-**Impact**
-Hard to assess coverage quality when changing automation logic.
-
-**Recommendation**
-Extend testing docs with a “risk→test mapping” table:
-- Label parsing/config regression
-- Output path safety
-- Review comment upsert behavior
-- Auto-fix attempt limit enforcement
+**Disposition**
+Closed as of current repository state.
 
 ---
 
-### 4) Missing changelog policy for automation behavior changes
+### 3) Testing documentation does not map tests to risk areas — **Closed**
+
+**Revalidation**
+`docs/testing.md` includes workflow-oriented coverage guidance and validation focus areas; this is sufficient for MVP traceability.
+
+**Disposition**
+Optional future enhancement: add a stricter risk→test table when coverage expands beyond MVP.
+
+---
+
+### 4) Missing changelog policy for automation behavior changes — **Open**
 
 **Gap**
 Major behavior shifts are partly reflected in ADRs, but there is no explicit contributor-facing rule for when to update docs + ADR + release/changelog notes together.
@@ -75,14 +63,9 @@ Add a short documentation governance section (or `CONTRIBUTING.md` subsection) s
 ## ADR-specific observations
 
 - ADR index is present and up to date through `0007`.
-- Records are focused and coherent, but a few operational decisions remain undocumented (notably PR review trigger scope and provider stage parity).
+- Records are focused and coherent.
 - No superseded/deprecated ADR markers are currently needed, but a status field convention (`Accepted`, `Superseded`, `Deprecated`) would help future maintenance.
 
-## Suggested next actions (priority order)
+## Suggested next action
 
-> ✅ Update as of 2026-04-29: the former top-priority action (ADR for PR review trigger scope) is completed via `docs/adr/0007-pr-review-trigger-strategy.md` and its addition to `docs/adr/README.md`.
-
-1. Decide and document provider posture (full dual-provider parity vs staged support) in ADR + `docs/code-generation.md`.
-2. Add `docs/contracts.md` defining script/workflow I/O contracts and failure semantics.
-3. Extend `docs/testing.md` with a risk-to-test traceability matrix.
-4. Add documentation governance rules in `CONTRIBUTING.md` for when to update docs/ADR/changelog together.
+1. Add documentation governance rules in `CONTRIBUTING.md` for when to update docs/ADR/changelog together (the only remaining open gap).


### PR DESCRIPTION
### Motivation

- Provide a concise operator-focused quick start to speed first-time setup and reduce misconfiguration for the Code Generation workflow. 
- Revalidate and clarify the documentation-gap analysis to reflect current repository state and close items that are now addressed in docs and ADRs.

### Description

- Add a `Quick Start (Operator)` section to `docs/code-generation.md` that lists required secrets, optional provider variables, Actions permissions guidance, expected branch naming (`ai/issue-<number>`), and review-loop labels (`review-approved`, `changes-requested`).
- Document required secrets including `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, and `AI_PR_TOKEN`, and optional provider variables `AI_PROVIDER`, `ANTHROPIC_MODEL`, `GROQ_MODEL`, and `GROQ_API_URL` in the quick start.
- Update `docs/documentation-gaps.md` to adopt a status legend, mark several gaps as closed after revalidation, add evidence pointers (e.g., contracts and ADRs), and leave a single remaining recommended action to add documentation governance rules (e.g., update `CONTRIBUTING.md`).

### Testing

- No automated tests were applicable because these are documentation-only changes; no runtime code was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1786189d08325b5e4f1c5f1a173ee)