### PR TITLE
[AI] Issue #92: [BUG] groq_client.mjs crashe avec TypeError sur les réponses 429 (headers non gardé)

### DIFF
--- a/scripts/lib/groq_client.mjs
+++ b/scripts/lib/groq_client.mjs
@@ -3,7 +3,7 @@ import { log } from './logger.mjs';
 function parseWaitMs(rawText, headers) {
   const match = rawText.match(/Please try again in (\d+(?:\.\d+)?)s/i);
   if (match) return Math.ceil(parseFloat(match[1]) * 1000);
-  const retryAfter = headers.get('Retry-After');
+  const retryAfter = headers?.get('Retry-After');
   if (retryAfter != null) {
     const secs = parseFloat(retryAfter);
     if (!isNaN(secs) && secs >= 0) return Math.ceil(secs * 1000);

--- a/scripts/tests/groq_client.test.mjs
+++ b/scripts/tests/groq_client.test.mjs
@@ -4,10 +4,11 @@ import { callGroq } from '../lib/groq_client.mjs';
 
 const BASE_ARGS = { prompt: 'go', systemPrompt: 'You are a test assistant.', apiKey: 'key', model: 'llama-3.1-8b-instant', apiUrl: 'https://api.test' };
 
-function makeResponse(body, status = 200) {
+function makeResponse(body, status = 200, headers = {}) {
   return {
     ok: status >= 200 && status < 300,
     status,
+    headers: { get: (name) => headers[name] ?? null },
     text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   };
 }
@@ -116,4 +117,43 @@ test('callGroq omits max_tokens when maxTokens is not provided', async () => {
   };
   await callGroq(BASE_ARGS);
   assert.equal('max_tokens' in capturedBody, false);
+});
+
+test('callGroq retries on 429 and succeeds on next attempt', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    if (calls === 1) return makeResponse('Please try again in 0s', 429);
+    return makeResponse({ choices: [{ message: { content: '{}' } }] });
+  };
+  const result = await callGroq(BASE_ARGS);
+  assert.equal(result, '{}');
+  assert.equal(calls, 2);
+});
+
+test('callGroq retries on 429 with Retry-After header', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    if (calls === 1) return makeResponse('rate limited', 429, { 'Retry-After': '0' });
+    return makeResponse({ choices: [{ message: { content: '{}' } }] });
+  };
+  const result = await callGroq(BASE_ARGS);
+  assert.equal(result, '{}');
+  assert.equal(calls, 2);
+});
+
+test('callGroq exhausts retries on persistent 429 and throws', async () => {
+  process.env.GROQ_MAX_RETRIES = '1';
+  let calls = 0;
+  try {
+    globalThis.fetch = async () => {
+      calls++;
+      return makeResponse('Please try again in 0s', 429);
+    };
+    await assert.rejects(() => callGroq(BASE_ARGS), /Groq API HTTP error 429/);
+    assert.equal(calls, 2);
+  } finally {
+    delete process.env.GROQ_MAX_RETRIES;
+  }
 });


### PR DESCRIPTION
## AI Generated Change

Fixed TypeError in groq_client.mjs by adding optional chaining to headers.get('Retry-After')

Closes #92