### PR TITLE
docs: add pipeline resilience analysis and GitHub issue pack

### DIFF
--- a/docs/pipeline-resilience-analysis.md
+++ b/docs/pipeline-resilience-analysis.md
@@ -27,6 +27,11 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
 - **Unit + smoke tests** reduce cross-module regressions.
 - **Constrained output paths** reduce unintended file changes.
 - **Workflow orchestration separated from Node.js logic** makes guardrails easier to test.
+- **`requireEnv()`** in `scripts/lib/config.mjs` fails fast on missing secrets at startup.
+- **`upsert_issue_validation_comment.mjs`** already applies upsert semantics for validation comments.
+- **`groq_client.mjs`** has configurable 429 retry with backoff (`GROQ_MAX_RETRIES`).
+- **`auto-fix-pr.yml`** sets `timeout-minutes: 10` at the job level.
+- **`auto_fix_pr.mjs`** registers a global `unhandledRejection` handler to prevent silent crashes.
 
 ### Potential weak points (if priority = near-zero failure)
 
@@ -37,6 +42,141 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
   - partial/invalid responses.
 - Incomplete recovery risk after run interruption (runner stop/cancel/restart).
 - Non-deterministic behavior in some operations (ordering, permissive parsing).
+
+---
+
+## Code-level gap analysis
+
+This section grounds each recommendation in concrete evidence from the current codebase. All file paths are relative to the repository root.
+
+### `scripts/lib/anthropic_client.mjs` — Zero fault tolerance
+
+The Anthropic client performs a single raw `fetch` with no retry, no timeout, and no error classification. Any transient failure (network reset, 5xx, gateway timeout) throws immediately and propagates uncaught to the caller.
+
+```js
+// No retry, no timeout, no classification
+const response = await fetch(apiUrl || ANTHROPIC_API_URL_DEFAULT, { ... });
+if (!response.ok) {
+  throw new Error(`Anthropic API HTTP error ${response.status}: ${rawText}`);
+}
+```
+
+All Anthropic-backed stages (generation, review, autofix) inherit this fragility. This is the highest-priority gap in the codebase.
+
+### `scripts/lib/groq_client.mjs` — Partial (429-only) retry
+
+Groq has configurable retry logic (`GROQ_MAX_RETRIES`), but only for HTTP 429. Any 5xx error throws immediately without retry. There is also no per-call timeout: a hung connection blocks the runner until the GitHub Actions step timeout fires.
+
+```js
+if (response.status === 429) {
+  // Retries with backoff — good
+  await new Promise((resolve) => setTimeout(resolve, waitMs));
+  continue;
+}
+if (!response.ok) {
+  // 5xx: throws immediately, no retry
+  throw new Error(`Groq API HTTP error ${response.status}: ${rawText}`);
+}
+```
+
+The 429 handling is a good model that should be extended to 5xx and applied to the Anthropic client.
+
+### `scripts/lib/llm_client.mjs` — Provider fallback masks permanent errors
+
+The LLM router falls back to the secondary provider on **any** error, including permanent 4xx (invalid API key, malformed request). This silently hides configuration errors and wastes attempts against a second provider that will also fail.
+
+```js
+for (const provider of ordered) {
+  try {
+    return await provider.call(args);
+  } catch (error) {
+    // 401, 400, 422 all trigger fallback — not just transient errors
+    errors.push(`${provider.name}: ${error.message}`);
+  }
+}
+```
+
+A 401 from Anthropic (invalid API key) should fail fast, not silently retry against Groq. The fallback should only activate on `TRANSIENT` errors once the error taxonomy is in place.
+
+### `.github/workflows/code-generation.yml` — Missing job timeout
+
+The `generate-pr` job has no `timeout-minutes`. A hung LLM call can block the runner for up to 6 hours (GitHub Actions default limit). By contrast, `auto-fix-pr.yml` correctly sets `timeout-minutes: 10`.
+
+```yaml
+# code-generation.yml — no timeout
+generate-pr:
+  runs-on: ubuntu-latest
+  # timeout-minutes: <missing>
+
+# auto-fix-pr.yml — bounded
+auto-fix:
+  timeout-minutes: 10
+```
+
+Adding `timeout-minutes: 15` to `generate-pr` is a one-line, zero-risk fix with immediate impact.
+
+### `scripts/lib/logger.mjs` — Incomplete structured fields
+
+The logger already emits JSON lines (good), but lacks the fields needed for cross-run correlation and error diagnosis.
+
+Current output shape: `{ level, msg, ...data }`
+
+Missing fields relative to the recommended schema:
+
+| Field | Status | Impact if absent |
+|---|---|---|
+| `run_id` | Missing | Cannot correlate lines across multi-job workflows |
+| `step` | Missing | Cannot locate which pipeline stage failed |
+| `attempt` | Missing | Retry context invisible in logs |
+| `duration_ms` | Missing | No per-step latency data |
+| `error_class` | Missing | Cannot distinguish transient from permanent failures in logs |
+
+The `log()` and `error()` functions in `scripts/lib/logger.mjs` are the right extension point. The change is purely additive.
+
+### `scripts/auto_fix_pr.mjs` — Labels as implicit checkpoint, `ghFetch` without retry
+
+**Positive**: Attempt state is tracked by counting PR labels prefixed `auto-fix-attempt-`. This is a lightweight checkpoint mechanism that survives runner restarts. Label creation already tolerates 422 (existing label), which is a correct upsert pattern.
+
+**Gap 1**: If the label API call fails *after* the AI work is done, the checkpoint is not saved. The attempt is lost and will be re-counted incorrectly on the next run.
+
+**Gap 2**: All GitHub API calls are made via `ghFetch`, which has no retry and no per-call timeout. A single transient network error on any of them (diff fetch, label fetch, comment post) fails the entire run permanently, even though the failure is transient.
+
+```js
+async function ghFetch(endpoint, options = {}) {
+  try {
+    return await fetch(`${githubApiBase}${endpoint}`, { ... });
+  } catch (err) {
+    // Network error: re-throws immediately — no retry
+    throw new Error(`Network error calling GitHub API (${endpoint}): ${err.message}`, { cause: err });
+  }
+}
+```
+
+### Partial idempotence coverage
+
+Idempotence is already partially implemented but inconsistently applied:
+
+| Operation | Status | File |
+|---|---|---|
+| Validation comment | Upsert by marker (✅) | `upsert_issue_validation_comment.mjs` |
+| Auto-fix label creation | 422-tolerant (✅) | `auto_fix_pr.mjs` |
+| Generated file writes | Unconditional overwrite (❌) | `scripts/lib/output_writer.mjs` |
+| Label management | Needs verification | `scripts/manage_labels.mjs` |
+
+File writes in `output_writer.mjs` are not idempotent by design (they always overwrite), but they are also not checked against expected state before writing. A re-run with the same inputs will produce the same output files, which is acceptable, but intermediate states during a partial failure may leave inconsistent file sets.
+
+### Gap summary table
+
+| File / Artifact | Gap | Severity | Effort |
+|---|---|---|---|
+| `scripts/lib/anthropic_client.mjs` | No retry, no timeout, no error class | **High** | Medium |
+| `scripts/lib/groq_client.mjs` | 5xx not retried, no call timeout | **High** | Low |
+| `scripts/lib/llm_client.mjs` | Fallback triggered on permanent errors | **High** | Low |
+| `.github/workflows/code-generation.yml` | No job timeout | **High** | Trivial |
+| `scripts/auto_fix_pr.mjs` (`ghFetch`) | No retry/timeout on GitHub API calls | **Medium** | Medium |
+| `scripts/lib/logger.mjs` | Missing `run_id`, `step`, `attempt`, `error_class` | **Medium** | Low |
+| `scripts/lib/output_writer.mjs` | No idempotence check on file writes | **Low** | Low |
+| `config/models.yaml` | Values not validated at startup | **Low** | Low |
 
 ---
 
@@ -54,6 +194,7 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
   - `TRANSIENT` => bounded retry.
   - `PERMANENT` => immediate fail-fast.
   - `UNKNOWN` => one confirmation attempt, then fail.
+- **Primary targets**: `anthropic_client.mjs`, `groq_client.mjs`, `llm_client.mjs`.
 
 ## 2) Robust retry strategy for external calls
 
@@ -63,6 +204,8 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
 - Max attempt budget per operation (e.g., 3 to 5 attempts).
 - Strict per-call timeout + step-level timeout.
 - Simple circuit breaker (if N consecutive failures, stop early).
+- **Primary targets**: `anthropic_client.mjs`, `groq_client.mjs` (extend to 5xx), `ghFetch` in `auto_fix_pr.mjs`.
+- **Quick win**: add `timeout-minutes: 15` to `code-generation.yml` immediately.
 
 ## 3) Strict idempotence for critical steps
 
@@ -71,6 +214,7 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
 - Compute idempotency keys (issue id, commit SHA, step).
 - Before writing, verify expected state is not already applied.
 - For labels/comments, prefer upsert semantics over append.
+- **Primary targets**: `output_writer.mjs`, `manage_labels.mjs`.
 
 ## 4) Checkpointing and explicit run state
 
@@ -82,6 +226,7 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
   - latest relevant external results.
 - Resume only when checkpoint is valid.
 - Invalidate checkpoint cleanly when inputs change.
+- **Note**: the label-based attempt counter in `auto_fix_pr.mjs` is a good foundation — extend it with atomic write semantics.
 
 ## 5) Harden input/output validation
 
@@ -93,6 +238,7 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
   - required prompt/config files.
 - Validate external payload schemas systematically.
 - For invalid payloads, classify correctly (often transient if truncated).
+- **Primary targets**: `scripts/lib/config.mjs` (already has `requireEnv()`, extend to prompts/files), `scripts/lib/prompts.mjs`.
 
 ## 6) Reliability-focused observability
 
@@ -107,6 +253,7 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
   - average step latency,
   - MTTR (mean time to recovery).
 - Always emit end-of-run summary, including failures.
+- **Primary target**: `scripts/lib/logger.mjs` (additive changes only).
 
 ---
 
@@ -114,16 +261,20 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
 
 ### Phase 1 (quick wins, high ROI)
 
-1. Add a shared `retry_with_backoff` utility.
-2. Add shared error taxonomy (`TRANSIENT/PERMANENT/UNKNOWN`).
-3. Apply retries + timeouts to external clients (LLM/GitHub).
-4. Add standardized log fields (`run_id`, `attempt`, `error_class`).
+1. Add `timeout-minutes: 15` to `code-generation.yml` `generate-pr` job.
+2. Add a shared `retry_with_backoff` utility in `scripts/lib/`.
+3. Add shared error taxonomy (`TRANSIENT/PERMANENT/UNKNOWN`) in `scripts/lib/`.
+4. Extend `groq_client.mjs` retry to cover 5xx in addition to 429.
+5. Apply the same retry pattern to `anthropic_client.mjs`.
+6. Fix `llm_client.mjs` fallback to only trigger on `TRANSIENT` errors.
+7. Add standardized log fields (`run_id`, `attempt`, `error_class`) to `logger.mjs`.
 
 ### Phase 2 (advanced resilience)
 
-1. Add run-level checkpoints.
-2. Make all write-side operations idempotent (labels, comments, outputs).
-3. Add exportable reliability metrics.
+1. Add retry + timeout to `ghFetch` in `auto_fix_pr.mjs`.
+2. Add run-level checkpoints (extend label-based tracking with atomic writes).
+3. Make all write-side operations idempotent (labels, comments, outputs).
+4. Add exportable reliability metrics.
 
 ### Phase 3 (hardening)
 
@@ -147,6 +298,8 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
 - Non-regression tests:
   - no duplicate labels/comments,
   - no writes outside allowed scope.
+- Specific regression guard:
+  - `llm_client.mjs` fallback must NOT trigger on 401/403.
 
 ---
 
@@ -156,6 +309,7 @@ The pipeline already has strong safety foundations (label gates, bounded auto-fi
 - **More control logic** increases complexity, mitigated by tests + observability.
 - **Over-aggressive retries** can hide systemic incidents:
   - use bounded budgets + circuit breaker.
+- **Provider fallback** is useful for `TRANSIENT` failures but dangerous for `PERMANENT` ones — the fix must be precise.
 
 ---
 
@@ -169,4 +323,9 @@ If the priority is "**I prefer slower runs, but I do not want failures**", the m
 4. error classification,
 5. actionable observability.
 
-The repository is already well-structured for this direction; what is mostly missing is a **uniform, tested transient-failure handling layer**.
+The repository is already well-structured for this direction. The most concrete gaps are:
+- `anthropic_client.mjs` has zero fault tolerance and must be the first target.
+- `llm_client.mjs` masks permanent errors behind provider fallback — a correctness bug, not just a resilience gap.
+- `code-generation.yml` missing `timeout-minutes` is a trivial one-line fix with immediate impact.
+
+What is mostly missing is a **uniform, tested transient-failure handling layer** applied consistently across both LLM clients and the GitHub API client.

--- a/docs/pipeline-resilience-analysis.md
+++ b/docs/pipeline-resilience-analysis.md
@@ -1,0 +1,172 @@
+# Pipeline Resilience Analysis (priority: do not fail)
+
+## Context and objective
+
+You stated a clear constraint: **speed is secondary**; the main priority is **fault tolerance** and **stability** for the generation/fix pipeline.
+
+This analysis is based on existing repository conventions (label-gated triggers, auto-fix attempt limits, smoke/unit tests, constrained output scope) and proposes a resilience-first hardening plan.
+
+## Executive summary
+
+The pipeline already has strong safety foundations (label gates, bounded auto-fix retries, dedicated tests, constrained outputs). To maximize resilience, the top priorities are:
+
+1. **Make every step idempotent** (safe to replay).
+2. **Add bounded retries with exponential backoff + jitter** for external calls.
+3. **Differentiate transient vs permanent errors** for smart fail-fast behavior.
+4. **Add checkpoints and resume support** (explicit attempt state).
+5. **Improve observability** (structured logs + reliability metrics).
+
+---
+
+## Current resilience assessment
+
+### Existing strengths
+
+- **Label-gated triggering** reduces accidental runs.
+- **Auto-fix retry cap (3)** prevents infinite loops.
+- **Unit + smoke tests** reduce cross-module regressions.
+- **Constrained output paths** reduce unintended file changes.
+- **Workflow orchestration separated from Node.js logic** makes guardrails easier to test.
+
+### Potential weak points (if priority = near-zero failure)
+
+- External API dependencies (LLM, GitHub, etc.) are exposed to:
+  - timeouts,
+  - intermittent network errors,
+  - rate limiting,
+  - partial/invalid responses.
+- Incomplete recovery risk after run interruption (runner stop/cancel/restart).
+- Non-deterministic behavior in some operations (ordering, permissive parsing).
+
+---
+
+## Prioritized recommendations (impact order)
+
+## 1) Standard error policy (transient vs permanent)
+
+**Goal**: avoid noisy failures and avoid useless retries on unrecoverable errors.
+
+- Classify errors into 3 classes:
+  - `TRANSIENT`: timeout, 429, 5xx, network reset.
+  - `PERMANENT`: business 4xx (invalid input, missing secret).
+  - `UNKNOWN`: treat conservatively (one guarded retry, then stop).
+- Enforce explicit behavior:
+  - `TRANSIENT` => bounded retry.
+  - `PERMANENT` => immediate fail-fast.
+  - `UNKNOWN` => one confirmation attempt, then fail.
+
+## 2) Robust retry strategy for external calls
+
+**Goal**: absorb intermittent failures without destabilizing the full run.
+
+- Retry with **exponential backoff + jitter**.
+- Max attempt budget per operation (e.g., 3 to 5 attempts).
+- Strict per-call timeout + step-level timeout.
+- Simple circuit breaker (if N consecutive failures, stop early).
+
+## 3) Strict idempotence for critical steps
+
+**Goal**: allow safe reruns without inconsistent side effects.
+
+- Compute idempotency keys (issue id, commit SHA, step).
+- Before writing, verify expected state is not already applied.
+- For labels/comments, prefer upsert semantics over append.
+
+## 4) Checkpointing and explicit run state
+
+**Goal**: resume safely after interruption without starting from scratch.
+
+- Persist minimal state (json/artifact) per run:
+  - current step,
+  - attempts consumed,
+  - latest relevant external results.
+- Resume only when checkpoint is valid.
+- Invalidate checkpoint cleanly when inputs change.
+
+## 5) Harden input/output validation
+
+**Goal**: fail early on certain causes and avoid late-stage failures.
+
+- Validate at startup:
+  - required secrets,
+  - config format,
+  - required prompt/config files.
+- Validate external payload schemas systematically.
+- For invalid payloads, classify correctly (often transient if truncated).
+
+## 6) Reliability-focused observability
+
+**Goal**: accelerate diagnosis and continuous improvement.
+
+- Structured JSON logs:
+  - `run_id`, `step`, `attempt`, `duration_ms`, `error_class`.
+- Key metrics:
+  - overall success rate,
+  - retry rate,
+  - errors by class,
+  - average step latency,
+  - MTTR (mean time to recovery).
+- Always emit end-of-run summary, including failures.
+
+---
+
+## Implementation plan (resilience MVP)
+
+### Phase 1 (quick wins, high ROI)
+
+1. Add a shared `retry_with_backoff` utility.
+2. Add shared error taxonomy (`TRANSIENT/PERMANENT/UNKNOWN`).
+3. Apply retries + timeouts to external clients (LLM/GitHub).
+4. Add standardized log fields (`run_id`, `attempt`, `error_class`).
+
+### Phase 2 (advanced resilience)
+
+1. Add run-level checkpoints.
+2. Make all write-side operations idempotent (labels, comments, outputs).
+3. Add exportable reliability metrics.
+
+### Phase 3 (hardening)
+
+1. Add targeted chaos scenarios (simulated timeout/429/5xx).
+2. Define SLO targets (e.g., >99% runs without manual intervention).
+3. Tune retry budgets based on observed production behavior.
+
+---
+
+## Recommended anti-failure tests
+
+- Unit tests:
+  - error classification,
+  - backoff/jitter behavior,
+  - timeout handling,
+  - writer idempotence.
+- Smoke tests:
+  - transient failure recovered in N attempts,
+  - permanent failure stops immediately,
+  - interrupted run resumes with valid checkpoint.
+- Non-regression tests:
+  - no duplicate labels/comments,
+  - no writes outside allowed scope.
+
+---
+
+## Risks and trade-offs
+
+- **More resilience = more latency** (acceptable for this objective).
+- **More control logic** increases complexity, mitigated by tests + observability.
+- **Over-aggressive retries** can hide systemic incidents:
+  - use bounded budgets + circuit breaker.
+
+---
+
+## Conclusion
+
+If the priority is "**I prefer slower runs, but I do not want failures**", the main axis is:
+
+1. smart retries,
+2. idempotence,
+3. resume checkpoints,
+4. error classification,
+5. actionable observability.
+
+The repository is already well-structured for this direction; what is mostly missing is a **uniform, tested transient-failure handling layer**.

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -69,43 +69,7 @@ https://github.com/koydas/autonomous-dev-loop/issues/116
 **Title**
 `[FEATURE] Early validation of prerequisites and external payloads`
 
-**Body (copy/paste):**
-```md
-## 🎯 Goal
-Add a feature that addresses a clear product need.
-
-## 📍 Context
-- Repo: autonomous-dev-loop
-- Domain: Reliable fail-fast behavior
-- Component: `scripts/lib/config.mjs`, `scripts/lib/prompts.mjs`, external payload parsing
-
-## 🚀 Description
-Harden startup validation (secrets/config/prompts) and enforce schema validation for external payloads before costly steps.
-
-Current state:
-- `requireEnv()` in `config.mjs` already validates required secrets at startup — good.
-- Prompt files are loaded on demand but their existence is not verified before the LLM call.
-- External payload structure (GitHub event JSON, LLM response JSON) is parsed without schema validation.
-
-## 🧩 Scope
-- In:
-  - Extend startup checks to prompt and config file existence (`scripts/lib/prompts.mjs`).
-  - Validation of expected payload structure for GitHub events and LLM responses.
-  - Actionable error messages.
-- Out:
-  - Full redesign of global config format.
-
-## 🧪 Acceptance criteria
-- [ ] Functional
-  - Pipeline fails early with explicit errors when prerequisites are missing.
-- [ ] Edge cases covered
-  - Incomplete/malformed payloads are classified correctly.
-- [ ] Tests included
-  - Unit tests for config + payload validation.
-
-## ⚙️ Constraints
-Do not hide root causes behind generic messages.
-```
+https://github.com/koydas/autonomous-dev-loop/issues/129
 
 ---
 

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -42,47 +42,7 @@ https://github.com/koydas/autonomous-dev-loop/issues/109
 **Title**
 `[FEATURE] Bounded exponential retry with jitter for external calls`
 
-**Body (copy/paste):**
-```md
-## 🎯 Goal
-Add a feature that addresses a clear product need.
-
-## 📍 Context
-- Repo: autonomous-dev-loop
-- Domain: Transient failure tolerance
-- Component: `scripts/lib/anthropic_client.mjs`, `scripts/lib/groq_client.mjs`, `scripts/auto_fix_pr.mjs` (`ghFetch`)
-
-## 🚀 Description
-Create a shared retry utility with exponential backoff + jitter, per-attempt timeout, and max-attempt budget.
-
-Value: better recovery from intermittent incidents without infinite loops.
-
-Current state:
-- `anthropic_client.mjs`: single `fetch`, zero retry, zero timeout.
-- `groq_client.mjs`: retries on 429 only; 5xx throws immediately; no per-call timeout.
-- `ghFetch` in `auto_fix_pr.mjs`: no retry, no timeout — a single network error fails the entire run.
-
-## 🧩 Scope
-- In:
-  - `retry_with_backoff` utility in `scripts/lib/`.
-  - Configurable parameters (max attempts, base delay, max delay, timeout).
-  - Integrate into `anthropic_client.mjs` and extend `groq_client.mjs` to cover 5xx.
-  - Apply to `ghFetch` in `auto_fix_pr.mjs` for GitHub API calls.
-- Out:
-  - Global pipeline performance optimization.
-
-## 🧪 Acceptance criteria
-- [ ] Functional
-  - Transient external failures (5xx, network reset) are retried automatically.
-- [ ] Edge cases covered
-  - Max attempt count and timeout budget are strictly enforced.
-  - 429 retry-after header is respected (already implemented in Groq — preserve this).
-- [ ] Tests included
-  - Unit tests for backoff calculation and budget stop behavior.
-
-## ⚙️ Constraints
-Reliability is more important than speed. Retries must stay bounded and observable.
-```
+https://github.com/koydas/autonomous-dev-loop/issues/111
 
 ---
 

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -78,44 +78,7 @@ https://github.com/koydas/autonomous-dev-loop/issues/129
 **Title**
 `[FEATURE] Structured logs and pipeline health metrics`
 
-**Body (copy/paste):**
-```md
-## 🎯 Goal
-Add a feature that addresses a clear product need.
-
-## 📍 Context
-- Repo: autonomous-dev-loop
-- Domain: Operational diagnosability
-- Component: `scripts/lib/logger.mjs` + orchestration hooks
-
-## 🚀 Description
-Standardize structured logs and produce key metrics (success, retries, error classes, per-step latency) to accelerate failure diagnosis.
-
-Current state:
-- `logger.mjs` already emits JSON lines with `{ level, msg, ...data }` — good foundation.
-- Missing fields: `run_id`, `step`, `attempt`, `duration_ms`, `error_class`.
-- Without `run_id`, log lines from a single run cannot be correlated in multi-job workflows.
-- No end-of-run summary is emitted.
-
-## 🧩 Scope
-- In:
-  - Standard fields (`run_id`, `step`, `attempt`, `duration_ms`, `error_class`) added to `logger.mjs`.
-  - End-of-run summary for success/failure.
-  - Basic metric export through logs.
-- Out:
-  - Mandating an external observability platform.
-
-## 🧪 Acceptance criteria
-- [ ] Functional
-  - Each run emits end-to-end correlatable logs.
-- [ ] Edge cases covered
-  - Errors before full initialization are still traceable.
-- [ ] Tests included
-  - Unit tests for logger + smoke checks for required fields.
-
-## ⚙️ Constraints
-Keep logs useful and stable; avoid excessive verbosity by default.
-```
+https://github.com/koydas/autonomous-dev-loop/issues/132
 
 ---
 

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -33,47 +33,7 @@ Use this table to decide which issues to open first.
 **Title**
 `[FEATURE] Unified TRANSIENT/PERMANENT/UNKNOWN error taxonomy`
 
-**Body (copy/paste):**
-```md
-## 🎯 Goal
-Add a feature that addresses a clear product need.
-
-## 📍 Context
-- Repo: autonomous-dev-loop
-- Domain: Pipeline reliability
-- Component: `scripts/lib/*` (error handling + external clients)
-
-## 🚀 Description
-Introduce a shared error taxonomy (`TRANSIENT`, `PERMANENT`, `UNKNOWN`) used across modules calling external services (LLM, GitHub API).
-
-Value: consistent retry/fail-fast decisions and reduced behavioral drift across scripts.
-
-Current state:
-- `groq_client.mjs` retries on 429 only — 5xx is not retried.
-- `anthropic_client.mjs` has no retry at all.
-- `llm_client.mjs` falls back to secondary provider on **any** error, including permanent 4xx (e.g. invalid API key). This is a correctness bug: a 401 should fail fast, not trigger provider fallback.
-
-## 🧩 Scope
-- In:
-  - Create a shared error classification module.
-  - Explicitly map known cases (timeout, 429, 5xx, business 4xx, invalid payload).
-  - Expose a simple API consumed by existing clients.
-  - Fix `llm_client.mjs` to only fall back on `TRANSIENT` errors.
-- Out:
-  - Full refactor of unrelated scripts.
-
-## 🧪 Acceptance criteria
-- [ ] Functional
-  - Errors are deterministically classified according to documented rules.
-- [ ] Edge cases covered
-  - Ambiguous cases (`UNKNOWN`) are explicitly handled.
-  - `llm_client.mjs` does NOT fall back on 401/403/400.
-- [ ] Tests included
-  - Unit tests for 429/5xx/timeout/4xx/invalid payload classification.
-
-## ⚙️ Constraints
-No heavy new dependencies; keep API minimal and stable.
-```
+https://github.com/koydas/autonomous-dev-loop/issues/109
 
 ---
 

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -9,6 +9,25 @@ How to use:
 
 ---
 
+## Priority matrix
+
+Use this table to decide which issues to open first.
+
+| Issue | Title (short) | Affected files | Phase | Urgency |
+|---|---|---|---|---|
+| 1 | Error taxonomy | `lib/anthropic_client.mjs`, `lib/groq_client.mjs`, `lib/llm_client.mjs` | 1 | **High** |
+| 2 | Retry + backoff | `lib/anthropic_client.mjs`, `lib/groq_client.mjs`, `auto_fix_pr.mjs` | 1 | **High** |
+| 5 | Early validation | `lib/config.mjs`, `lib/prompts.mjs` | 1 | **High** |
+| 6 | Structured logs | `lib/logger.mjs` | 1 | **Medium** |
+| 3 | Idempotence | `lib/output_writer.mjs`, `manage_labels.mjs` | 2 | **Medium** |
+| 4 | Checkpoints | `auto_fix_pr.mjs`, `workflows/` | 2 | **Medium** |
+| 8 | Circuit breaker | `lib/llm_client.mjs`, `auto_fix_pr.mjs` | 2 | **Low** |
+| 7 | Chaos tests | `scripts/tests/*.test.mjs` | 3 | **Low** |
+
+> **Quick win not listed above**: add `timeout-minutes: 15` to the `generate-pr` job in `.github/workflows/code-generation.yml`. Single-line change, zero risk, immediate impact — can be done as a standalone commit before any issue is opened.
+
+---
+
 ## Issue 1
 
 **Title**
@@ -29,11 +48,17 @@ Introduce a shared error taxonomy (`TRANSIENT`, `PERMANENT`, `UNKNOWN`) used acr
 
 Value: consistent retry/fail-fast decisions and reduced behavioral drift across scripts.
 
+Current state:
+- `groq_client.mjs` retries on 429 only — 5xx is not retried.
+- `anthropic_client.mjs` has no retry at all.
+- `llm_client.mjs` falls back to secondary provider on **any** error, including permanent 4xx (e.g. invalid API key). This is a correctness bug: a 401 should fail fast, not trigger provider fallback.
+
 ## 🧩 Scope
 - In:
   - Create a shared error classification module.
   - Explicitly map known cases (timeout, 429, 5xx, business 4xx, invalid payload).
   - Expose a simple API consumed by existing clients.
+  - Fix `llm_client.mjs` to only fall back on `TRANSIENT` errors.
 - Out:
   - Full refactor of unrelated scripts.
 
@@ -42,6 +67,7 @@ Value: consistent retry/fail-fast decisions and reduced behavioral drift across 
   - Errors are deterministically classified according to documented rules.
 - [ ] Edge cases covered
   - Ambiguous cases (`UNKNOWN`) are explicitly handled.
+  - `llm_client.mjs` does NOT fall back on 401/403/400.
 - [ ] Tests included
   - Unit tests for 429/5xx/timeout/4xx/invalid payload classification.
 
@@ -64,26 +90,33 @@ Add a feature that addresses a clear product need.
 ## 📍 Context
 - Repo: autonomous-dev-loop
 - Domain: Transient failure tolerance
-- Component: `scripts/lib/*client*.mjs`
+- Component: `scripts/lib/anthropic_client.mjs`, `scripts/lib/groq_client.mjs`, `scripts/auto_fix_pr.mjs` (`ghFetch`)
 
 ## 🚀 Description
 Create a shared retry utility with exponential backoff + jitter, per-attempt timeout, and max-attempt budget.
 
 Value: better recovery from intermittent incidents without infinite loops.
 
+Current state:
+- `anthropic_client.mjs`: single `fetch`, zero retry, zero timeout.
+- `groq_client.mjs`: retries on 429 only; 5xx throws immediately; no per-call timeout.
+- `ghFetch` in `auto_fix_pr.mjs`: no retry, no timeout — a single network error fails the entire run.
+
 ## 🧩 Scope
 - In:
-  - `retry_with_backoff` utility.
+  - `retry_with_backoff` utility in `scripts/lib/`.
   - Configurable parameters (max attempts, base delay, max delay, timeout).
-  - Integrate into LLM/GitHub clients.
+  - Integrate into `anthropic_client.mjs` and extend `groq_client.mjs` to cover 5xx.
+  - Apply to `ghFetch` in `auto_fix_pr.mjs` for GitHub API calls.
 - Out:
   - Global pipeline performance optimization.
 
 ## 🧪 Acceptance criteria
 - [ ] Functional
-  - Transient external failures are retried automatically.
+  - Transient external failures (5xx, network reset) are retried automatically.
 - [ ] Edge cases covered
   - Max attempt count and timeout budget are strictly enforced.
+  - 429 retry-after header is respected (already implemented in Groq — preserve this).
 - [ ] Tests included
   - Unit tests for backoff calculation and budget stop behavior.
 
@@ -106,15 +139,21 @@ Add a feature that addresses a clear product need.
 ## 📍 Context
 - Repo: autonomous-dev-loop
 - Domain: Re-runnability
-- Component: scripts managing labels/comments/output
+- Component: `scripts/lib/output_writer.mjs`, `scripts/manage_labels.mjs`
 
 ## 🚀 Description
 Make all write-side operations idempotent (labels, comments, generated files) so reruns do not create duplicates or inconsistent state.
 
+Current state (partial):
+- `upsert_issue_validation_comment.mjs` already applies upsert by marker — good model to follow.
+- `auto_fix_pr.mjs` label creation tolerates 422 (existing label) — good.
+- `output_writer.mjs` overwrites files unconditionally — acceptable but not verified against expected state.
+- `manage_labels.mjs` label operations need idempotence verification.
+
 ## 🧩 Scope
 - In:
   - "Already applied" checks before write operations.
-  - Upsert strategy for comments/labels.
+  - Upsert strategy for comments/labels (extend the pattern from `upsert_issue_validation_comment.mjs`).
   - Run-context idempotency keys.
 - Out:
   - Workflow trigger strategy changes.
@@ -146,16 +185,22 @@ Add a feature that addresses a clear product need.
 ## 📍 Context
 - Repo: autonomous-dev-loop
 - Domain: Execution continuity
-- Component: orchestration scripts/workflows
+- Component: `scripts/auto_fix_pr.mjs`, orchestration workflows
 
 ## 🚀 Description
 Add minimal progression state (checkpoint) to resume interrupted runs safely without restarting from scratch when safe.
+
+Current state:
+- `auto_fix_pr.mjs` already uses PR labels (`auto-fix-attempt-N`) as a lightweight checkpoint.
+- Gap: if the label API call fails after the AI work is done, the checkpoint is lost and the attempt counter is wrong on the next run.
+- `code-generation.yml` has no checkpoint mechanism at all.
 
 ## 🧩 Scope
 - In:
   - Minimal state format (step, attempts, timestamp, input version).
   - Conditional resume when checkpoint is valid.
   - Checkpoint invalidation when inputs change.
+  - Atomic write semantics for the checkpoint (write before declaring work done).
 - Out:
   - Long-term persistence beyond current run context.
 
@@ -186,15 +231,20 @@ Add a feature that addresses a clear product need.
 ## 📍 Context
 - Repo: autonomous-dev-loop
 - Domain: Reliable fail-fast behavior
-- Component: config/prompt loading + external payload parsing
+- Component: `scripts/lib/config.mjs`, `scripts/lib/prompts.mjs`, external payload parsing
 
 ## 🚀 Description
 Harden startup validation (secrets/config/prompts) and enforce schema validation for external payloads before costly steps.
 
+Current state:
+- `requireEnv()` in `config.mjs` already validates required secrets at startup — good.
+- Prompt files are loaded on demand but their existence is not verified before the LLM call.
+- External payload structure (GitHub event JSON, LLM response JSON) is parsed without schema validation.
+
 ## 🧩 Scope
 - In:
-  - Explicit checks for required secrets/files.
-  - Validation of expected payload structure.
+  - Extend startup checks to prompt and config file existence (`scripts/lib/prompts.mjs`).
+  - Validation of expected payload structure for GitHub events and LLM responses.
   - Actionable error messages.
 - Out:
   - Full redesign of global config format.
@@ -231,9 +281,15 @@ Add a feature that addresses a clear product need.
 ## 🚀 Description
 Standardize structured logs and produce key metrics (success, retries, error classes, per-step latency) to accelerate failure diagnosis.
 
+Current state:
+- `logger.mjs` already emits JSON lines with `{ level, msg, ...data }` — good foundation.
+- Missing fields: `run_id`, `step`, `attempt`, `duration_ms`, `error_class`.
+- Without `run_id`, log lines from a single run cannot be correlated in multi-job workflows.
+- No end-of-run summary is emitted.
+
 ## 🧩 Scope
 - In:
-  - Standard fields (`run_id`, `step`, `attempt`, `duration_ms`, `error_class`).
+  - Standard fields (`run_id`, `step`, `attempt`, `duration_ms`, `error_class`) added to `logger.mjs`.
   - End-of-run summary for success/failure.
   - Basic metric export through logs.
 - Out:
@@ -271,11 +327,18 @@ Add a feature that addresses a clear product need.
 ## 🚀 Description
 Add tests that simulate timeouts, 429, 5xx, and intermittent failures to validate automatic recovery and prevent regressions.
 
+Current state:
+- `groq_client.test.mjs` covers 429 retry — good.
+- No tests simulate 5xx on Anthropic or Groq.
+- No tests verify that `llm_client.mjs` does NOT fall back on permanent 4xx errors.
+- No timeout injection tests.
+
 ## 🧩 Scope
 - In:
   - Mocks/stubs for network/API failure simulation.
   - Recoverable vs non-recoverable cases.
   - Verification of attempt counters.
+  - Regression guard: `llm_client.mjs` fallback must not trigger on 401/403.
 - Out:
   - E2E tests requiring real third-party services.
 
@@ -306,7 +369,7 @@ Add a feature that addresses a clear product need.
 ## 📍 Context
 - Repo: autonomous-dev-loop
 - Domain: Protection against systemic incidents
-- Component: external-call orchestration
+- Component: `scripts/lib/llm_client.mjs`, `scripts/auto_fix_pr.mjs` (`ghFetch`)
 
 ## 🚀 Description
 Implement a minimal circuit breaker that stops a run when consecutive external failures indicate a systemic incident, avoiding wasted attempts.

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -1,0 +1,332 @@
+# GitHub Issue Copy/Paste Pack — Pipeline resilience
+
+This file is designed for fast issue creation in GitHub.
+
+How to use:
+1. Create a new GitHub issue.
+2. Copy one **Title** line.
+3. Copy the matching **Body** block exactly as-is.
+
+---
+
+## Issue 1
+
+**Title**
+`[FEATURE] Unified TRANSIENT/PERMANENT/UNKNOWN error taxonomy`
+
+**Body (copy/paste):**
+```md
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain: Pipeline reliability
+- Component: `scripts/lib/*` (error handling + external clients)
+
+## 🚀 Description
+Introduce a shared error taxonomy (`TRANSIENT`, `PERMANENT`, `UNKNOWN`) used across modules calling external services (LLM, GitHub API).
+
+Value: consistent retry/fail-fast decisions and reduced behavioral drift across scripts.
+
+## 🧩 Scope
+- In:
+  - Create a shared error classification module.
+  - Explicitly map known cases (timeout, 429, 5xx, business 4xx, invalid payload).
+  - Expose a simple API consumed by existing clients.
+- Out:
+  - Full refactor of unrelated scripts.
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+  - Errors are deterministically classified according to documented rules.
+- [ ] Edge cases covered
+  - Ambiguous cases (`UNKNOWN`) are explicitly handled.
+- [ ] Tests included
+  - Unit tests for 429/5xx/timeout/4xx/invalid payload classification.
+
+## ⚙️ Constraints
+No heavy new dependencies; keep API minimal and stable.
+```
+
+---
+
+## Issue 2
+
+**Title**
+`[FEATURE] Bounded exponential retry with jitter for external calls`
+
+**Body (copy/paste):**
+```md
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain: Transient failure tolerance
+- Component: `scripts/lib/*client*.mjs`
+
+## 🚀 Description
+Create a shared retry utility with exponential backoff + jitter, per-attempt timeout, and max-attempt budget.
+
+Value: better recovery from intermittent incidents without infinite loops.
+
+## 🧩 Scope
+- In:
+  - `retry_with_backoff` utility.
+  - Configurable parameters (max attempts, base delay, max delay, timeout).
+  - Integrate into LLM/GitHub clients.
+- Out:
+  - Global pipeline performance optimization.
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+  - Transient external failures are retried automatically.
+- [ ] Edge cases covered
+  - Max attempt count and timeout budget are strictly enforced.
+- [ ] Tests included
+  - Unit tests for backoff calculation and budget stop behavior.
+
+## ⚙️ Constraints
+Reliability is more important than speed. Retries must stay bounded and observable.
+```
+
+---
+
+## Issue 3
+
+**Title**
+`[FEATURE] Idempotence for labels/comments/generated outputs`
+
+**Body (copy/paste):**
+```md
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain: Re-runnability
+- Component: scripts managing labels/comments/output
+
+## 🚀 Description
+Make all write-side operations idempotent (labels, comments, generated files) so reruns do not create duplicates or inconsistent state.
+
+## 🧩 Scope
+- In:
+  - "Already applied" checks before write operations.
+  - Upsert strategy for comments/labels.
+  - Run-context idempotency keys.
+- Out:
+  - Workflow trigger strategy changes.
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+  - Re-running with same inputs does not change the final state.
+- [ ] Edge cases covered
+  - No duplicates after interrupted/retried runs.
+- [ ] Tests included
+  - Unit + smoke tests for duplicate prevention.
+
+## ⚙️ Constraints
+Preserve current business behavior; hardening only.
+```
+
+---
+
+## Issue 4
+
+**Title**
+`[FEATURE] Run progression checkpoints for interruption recovery`
+
+**Body (copy/paste):**
+```md
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain: Execution continuity
+- Component: orchestration scripts/workflows
+
+## 🚀 Description
+Add minimal progression state (checkpoint) to resume interrupted runs safely without restarting from scratch when safe.
+
+## 🧩 Scope
+- In:
+  - Minimal state format (step, attempts, timestamp, input version).
+  - Conditional resume when checkpoint is valid.
+  - Checkpoint invalidation when inputs change.
+- Out:
+  - Long-term persistence beyond current run context.
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+  - Interrupted runs can resume successfully for transient failures.
+- [ ] Edge cases covered
+  - Invalid checkpoints are detected and safely ignored.
+- [ ] Tests included
+  - Smoke test for resume + no-resume test on changed inputs.
+
+## ⚙️ Constraints
+Keep MVP-simple; no additional infrastructure.
+```
+
+---
+
+## Issue 5
+
+**Title**
+`[FEATURE] Early validation of prerequisites and external payloads`
+
+**Body (copy/paste):**
+```md
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain: Reliable fail-fast behavior
+- Component: config/prompt loading + external payload parsing
+
+## 🚀 Description
+Harden startup validation (secrets/config/prompts) and enforce schema validation for external payloads before costly steps.
+
+## 🧩 Scope
+- In:
+  - Explicit checks for required secrets/files.
+  - Validation of expected payload structure.
+  - Actionable error messages.
+- Out:
+  - Full redesign of global config format.
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+  - Pipeline fails early with explicit errors when prerequisites are missing.
+- [ ] Edge cases covered
+  - Incomplete/malformed payloads are classified correctly.
+- [ ] Tests included
+  - Unit tests for config + payload validation.
+
+## ⚙️ Constraints
+Do not hide root causes behind generic messages.
+```
+
+---
+
+## Issue 6
+
+**Title**
+`[FEATURE] Structured logs and pipeline health metrics`
+
+**Body (copy/paste):**
+```md
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain: Operational diagnosability
+- Component: `scripts/lib/logger.mjs` + orchestration hooks
+
+## 🚀 Description
+Standardize structured logs and produce key metrics (success, retries, error classes, per-step latency) to accelerate failure diagnosis.
+
+## 🧩 Scope
+- In:
+  - Standard fields (`run_id`, `step`, `attempt`, `duration_ms`, `error_class`).
+  - End-of-run summary for success/failure.
+  - Basic metric export through logs.
+- Out:
+  - Mandating an external observability platform.
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+  - Each run emits end-to-end correlatable logs.
+- [ ] Edge cases covered
+  - Errors before full initialization are still traceable.
+- [ ] Tests included
+  - Unit tests for logger + smoke checks for required fields.
+
+## ⚙️ Constraints
+Keep logs useful and stable; avoid excessive verbosity by default.
+```
+
+---
+
+## Issue 7
+
+**Title**
+`[FEATURE] Chaos test scenarios for transient failure recovery`
+
+**Body (copy/paste):**
+```md
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain: Robustness validation
+- Component: `scripts/tests/*.test.mjs` (including smoke)
+
+## 🚀 Description
+Add tests that simulate timeouts, 429, 5xx, and intermittent failures to validate automatic recovery and prevent regressions.
+
+## 🧩 Scope
+- In:
+  - Mocks/stubs for network/API failure simulation.
+  - Recoverable vs non-recoverable cases.
+  - Verification of attempt counters.
+- Out:
+  - E2E tests requiring real third-party services.
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+  - Transient scenarios pass with retries.
+- [ ] Edge cases covered
+  - Permanent scenarios fail fast without excessive retries.
+- [ ] Tests included
+  - New targeted unit + smoke suites.
+
+## ⚙️ Constraints
+Tests must be deterministic (no flakes).
+```
+
+---
+
+## Issue 8
+
+**Title**
+`[FEATURE] Lightweight circuit breaker for consecutive external failures`
+
+**Body (copy/paste):**
+```md
+## 🎯 Goal
+Add a feature that addresses a clear product need.
+
+## 📍 Context
+- Repo: autonomous-dev-loop
+- Domain: Protection against systemic incidents
+- Component: external-call orchestration
+
+## 🚀 Description
+Implement a minimal circuit breaker that stops a run when consecutive external failures indicate a systemic incident, avoiding wasted attempts.
+
+## 🧩 Scope
+- In:
+  - Configurable threshold for consecutive failures.
+  - Open/closed state within run context.
+  - Explicit logging when breaker opens.
+- Out:
+  - Distributed cross-run persistent circuit breaker.
+
+## 🧪 Acceptance criteria
+- [ ] Functional
+  - Run stops cleanly when threshold is exceeded.
+- [ ] Edge cases covered
+  - Correct reset behavior after an intermediate success.
+- [ ] Tests included
+  - Unit tests for breaker state transitions.
+
+## ⚙️ Constraints
+Behavior must remain predictable and easy to explain; configuration should stay simple.
+```

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -60,44 +60,7 @@ https://github.com/koydas/autonomous-dev-loop/issues/113
 **Title**
 `[FEATURE] Run progression checkpoints for interruption recovery`
 
-**Body (copy/paste):**
-```md
-## 🎯 Goal
-Add a feature that addresses a clear product need.
-
-## 📍 Context
-- Repo: autonomous-dev-loop
-- Domain: Execution continuity
-- Component: `scripts/auto_fix_pr.mjs`, orchestration workflows
-
-## 🚀 Description
-Add minimal progression state (checkpoint) to resume interrupted runs safely without restarting from scratch when safe.
-
-Current state:
-- `auto_fix_pr.mjs` already uses PR labels (`auto-fix-attempt-N`) as a lightweight checkpoint.
-- Gap: if the label API call fails after the AI work is done, the checkpoint is lost and the attempt counter is wrong on the next run.
-- `code-generation.yml` has no checkpoint mechanism at all.
-
-## 🧩 Scope
-- In:
-  - Minimal state format (step, attempts, timestamp, input version).
-  - Conditional resume when checkpoint is valid.
-  - Checkpoint invalidation when inputs change.
-  - Atomic write semantics for the checkpoint (write before declaring work done).
-- Out:
-  - Long-term persistence beyond current run context.
-
-## 🧪 Acceptance criteria
-- [ ] Functional
-  - Interrupted runs can resume successfully for transient failures.
-- [ ] Edge cases covered
-  - Invalid checkpoints are detected and safely ignored.
-- [ ] Tests included
-  - Smoke test for resume + no-resume test on changed inputs.
-
-## ⚙️ Constraints
-Keep MVP-simple; no additional infrastructure.
-```
+https://github.com/koydas/autonomous-dev-loop/issues/116
 
 ---
 

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -51,44 +51,7 @@ https://github.com/koydas/autonomous-dev-loop/issues/111
 **Title**
 `[FEATURE] Idempotence for labels/comments/generated outputs`
 
-**Body (copy/paste):**
-```md
-## 🎯 Goal
-Add a feature that addresses a clear product need.
-
-## 📍 Context
-- Repo: autonomous-dev-loop
-- Domain: Re-runnability
-- Component: `scripts/lib/output_writer.mjs`, `scripts/manage_labels.mjs`
-
-## 🚀 Description
-Make all write-side operations idempotent (labels, comments, generated files) so reruns do not create duplicates or inconsistent state.
-
-Current state (partial):
-- `upsert_issue_validation_comment.mjs` already applies upsert by marker — good model to follow.
-- `auto_fix_pr.mjs` label creation tolerates 422 (existing label) — good.
-- `output_writer.mjs` overwrites files unconditionally — acceptable but not verified against expected state.
-- `manage_labels.mjs` label operations need idempotence verification.
-
-## 🧩 Scope
-- In:
-  - "Already applied" checks before write operations.
-  - Upsert strategy for comments/labels (extend the pattern from `upsert_issue_validation_comment.mjs`).
-  - Run-context idempotency keys.
-- Out:
-  - Workflow trigger strategy changes.
-
-## 🧪 Acceptance criteria
-- [ ] Functional
-  - Re-running with same inputs does not change the final state.
-- [ ] Edge cases covered
-  - No duplicates after interrupted/retried runs.
-- [ ] Tests included
-  - Unit + smoke tests for duplicate prevention.
-
-## ⚙️ Constraints
-Preserve current business behavior; hardening only.
-```
+https://github.com/koydas/autonomous-dev-loop/issues/113
 
 ---
 

--- a/docs/pipeline-resilience-issues.md
+++ b/docs/pipeline-resilience-issues.md
@@ -87,45 +87,7 @@ https://github.com/koydas/autonomous-dev-loop/issues/132
 **Title**
 `[FEATURE] Chaos test scenarios for transient failure recovery`
 
-**Body (copy/paste):**
-```md
-## 🎯 Goal
-Add a feature that addresses a clear product need.
-
-## 📍 Context
-- Repo: autonomous-dev-loop
-- Domain: Robustness validation
-- Component: `scripts/tests/*.test.mjs` (including smoke)
-
-## 🚀 Description
-Add tests that simulate timeouts, 429, 5xx, and intermittent failures to validate automatic recovery and prevent regressions.
-
-Current state:
-- `groq_client.test.mjs` covers 429 retry — good.
-- No tests simulate 5xx on Anthropic or Groq.
-- No tests verify that `llm_client.mjs` does NOT fall back on permanent 4xx errors.
-- No timeout injection tests.
-
-## 🧩 Scope
-- In:
-  - Mocks/stubs for network/API failure simulation.
-  - Recoverable vs non-recoverable cases.
-  - Verification of attempt counters.
-  - Regression guard: `llm_client.mjs` fallback must not trigger on 401/403.
-- Out:
-  - E2E tests requiring real third-party services.
-
-## 🧪 Acceptance criteria
-- [ ] Functional
-  - Transient scenarios pass with retries.
-- [ ] Edge cases covered
-  - Permanent scenarios fail fast without excessive retries.
-- [ ] Tests included
-  - New targeted unit + smoke suites.
-
-## ⚙️ Constraints
-Tests must be deterministic (no flakes).
-```
+https://github.com/koydas/autonomous-dev-loop/issues/134
 
 ---
 


### PR DESCRIPTION
### Motivation

- Provide a resilience-first hardening plan for the generation/fix pipeline where fault tolerance is prioritized over speed. 
- Capture a concrete set of recommendations (retry/backoff, error taxonomy, idempotence, checkpoints, observability) and a phased implementation plan to reduce run failures. 
- Supply ready-to-copy GitHub issue bodies to accelerate incremental implementation of the resilience improvements.

### Description

- Add `docs/pipeline-resilience-analysis.md` containing an executive summary, current assessment, prioritized recommendations (error taxonomy, bounded retries with exponential backoff + jitter, idempotence, checkpoints, input validation, structured logs/metrics), an implementation roadmap (Phase 1–3), and suggested tests and risks. 
- Add `docs/pipeline-resilience-issues.md` which provides a copy/paste pack of 8 ready-made GitHub issues covering concrete work items including `TRANSIENT/PERMANENT/UNKNOWN` taxonomy, `retry_with_backoff` utility, idempotence for writes, run checkpoints, startup/payload validation, structured logging/metrics, chaos tests, and a lightweight circuit breaker. 
- Documents are authored to be actionable, include acceptance criteria for each issue, and prefer minimal new dependencies while keeping APIs small and testable.

### Testing

- No automated unit or integration tests were modified or required because this change is documentation-only. 
- No automated tests were run as part of this PR beyond any repository CI that validates docs formatting if configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54757c5a88325995224d002aff264)