### PR TITLE
fix(auto-fixer): skip self-modification when PR touches auto_fix_pr.mjs

### DIFF
--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -197,24 +197,19 @@ const diff = truncateToTokenBudget(filterDiff(rawDiff, diffBudget * 4), diffBudg
 
 const allChangedFiles = [...new Set([...rawDiff.matchAll(/^diff --git a\/(.*?) b\//gm)].map((m) => m[1]))];
 
-if (allChangedFiles.includes('scripts/auto_fix_pr.mjs')) {
-  log('Auto-fix skipped: PR modifies auto_fix_pr.mjs itself — self-modification guard triggered', { prNumber });
-  process.exit(0);
-}
-
-const changedFiles = allChangedFiles.filter(shouldIncludeFile);
-
 const SELF_PATH = 'scripts/auto_fix_pr.mjs';
-if (changedFiles.includes(SELF_PATH)) {
+if (allChangedFiles.includes(SELF_PATH)) {
   await ghFetch(`/repos/${owner}/${repo}/issues/${prNumber}/comments`, {
     method: 'POST',
     body: JSON.stringify({
-      body: `## 🤖 Auto-Fix Skipped\n\nThis PR modifies \`${SELF_PATH}\`. Automated self-modification is disabled to prevent feedback loops.`,
+      body: `## 🤖 Auto-Fix Skipped\n\nThis PR modifies \`${SELF_PATH}\`. Automated self-modification is disabled to prevent feedback loops. Please review and merge this PR manually.`,
     }),
   });
   log('Auto-fix skipped: PR modifies auto_fix_pr.mjs itself', { prNumber });
   process.exit(0);
 }
+
+const changedFiles = allChangedFiles.filter(shouldIncludeFile);
 
 const repoRoot = path.resolve(process.cwd());
 const fileContentParts = [];

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -166,9 +166,14 @@ if (!diffRes.ok) throw new Error(`Diff fetch failed: ${diffRes.status}`);
 const rawDiff = await diffRes.text();
 const diff = truncateToTokenBudget(filterDiff(rawDiff, diffBudget * 4), diffBudget);
 
-const changedFiles = [
-  ...new Set([...rawDiff.matchAll(/^diff --git a\/(.*?) b\//gm)].map((m) => m[1])),
-].filter(shouldIncludeFile);
+const allChangedFiles = [...new Set([...rawDiff.matchAll(/^diff --git a\/(.*?) b\//gm)].map((m) => m[1]))];
+
+if (allChangedFiles.includes('scripts/auto_fix_pr.mjs')) {
+  log('Auto-fix skipped: PR modifies auto_fix_pr.mjs itself — self-modification guard triggered', { prNumber });
+  process.exit(0);
+}
+
+const changedFiles = allChangedFiles.filter(shouldIncludeFile);
 
 const repoRoot = path.resolve(process.cwd());
 const fileContentParts = [];


### PR DESCRIPTION
Adds a guard that checks all files changed in the PR diff before
proceeding. If scripts/auto_fix_pr.mjs is among them, the script
exits cleanly (exit 0) to prevent the LLM from receiving a partial
view of its own source and catastrophically truncating it.

https://claude.ai/code/session_01AjMHGzmzyVhxwVp7C3NmhH