### PR TITLE
feat: implement checkpoint-resume — state persistence across GitHub Actions jobs

### DIFF
--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -10,6 +10,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  actions: write
 
 jobs:
   load-labels:
@@ -60,9 +61,47 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Find latest PR review run for checkpoint
+        id: review_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          else
+            BRANCH="${{ steps.pr.outputs.head_ref }}"
+          fi
+          RUN_ID=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow pr-review.yml \
+            --branch "$BRANCH" \
+            --status completed \
+            --json databaseId,conclusion \
+            --jq '[.[] | select(.conclusion == "success")] | .[0].databaseId // ""' 2>/dev/null || echo "")
+          echo "id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Download checkpoint artifact
+        if: steps.review_run.outputs.id != ''
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: checkpoints-pr-${{ github.event.pull_request.number || github.event.issue.number }}
+          run-id: ${{ steps.review_run.outputs.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./checkpoints
+
+      - name: Check prerequisite checkpoint
+        run: |
+          RUNID="pr-${{ github.event.pull_request.number || github.event.issue.number }}"
+          if [ ! -f "./checkpoints/${RUNID}/review.json" ]; then
+            echo "::error::Checkpoint 'review' not found for run '${RUNID}'. The pr-review workflow must complete successfully before auto-fix can proceed."
+            exit 1
+          fi
+
       - name: Apply AI fixes
         id: fix
         env:
+          CHECKPOINT_RUN_ID: pr-${{ github.event.pull_request.number || github.event.issue.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL }}
@@ -83,3 +122,12 @@ jobs:
           git add -A
           git diff --staged --quiet || git commit -m "fix(ai): auto-fix attempt ${ATTEMPT}"
           git push origin HEAD:"${PR_BRANCH}"
+
+      - name: Upload checkpoint artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkpoints-pr-${{ github.event.pull_request.number || github.event.issue.number }}
+          path: ./checkpoints
+          if-no-files-found: ignore
+          overwrite: true

--- a/.github/workflows/code-generation.yml
+++ b/.github/workflows/code-generation.yml
@@ -9,11 +9,16 @@ on:
         description: 'Issue number to process'
         required: true
         type: number
+      validate_run_id:
+        description: 'Run ID of the validate-issue workflow (for checkpoint resume)'
+        required: false
+        type: string
 
 permissions:
   contents: write
   pull-requests: write
   issues: write
+  actions: write
 
 jobs:
   load-labels:
@@ -70,9 +75,29 @@ jobs:
           echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
 
+      - name: Download checkpoint artifact
+        if: inputs.validate_run_id != ''
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: checkpoints-issue-${{ steps.issue.outputs.number }}
+          run-id: ${{ inputs.validate_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ./checkpoints
+
+      - name: Check prerequisite checkpoint
+        if: inputs.validate_run_id != ''
+        run: |
+          RUNID="issue-${{ steps.issue.outputs.number }}"
+          if [ ! -f "./checkpoints/${RUNID}/validate.json" ]; then
+            echo "::error::Checkpoint 'validate' not found for run '${RUNID}'. The validate-issue job must complete successfully before code-generation can proceed."
+            exit 1
+          fi
+
       - name: Generate AI change
         id: generate
         env:
+          CHECKPOINT_RUN_ID: issue-${{ steps.issue.outputs.number }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
           ISSUE_TITLE: ${{ steps.issue.outputs.title }}
           ISSUE_BODY: ${{ steps.issue.outputs.body }}
@@ -100,3 +125,12 @@ jobs:
             Closes #${{ steps.issue.outputs.number }}
           add-paths: |
             ${{ steps.generate.outputs.generated_paths }}
+
+      - name: Upload checkpoint artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkpoints-issue-${{ steps.issue.outputs.number }}
+          path: ./checkpoints
+          if-no-files-found: ignore
+          overwrite: true

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -28,23 +28,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "run_id=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           else
             BRANCH="${{ github.ref_name }}"
             PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
-            echo "run_id=pr-${PR:-${{ github.run_id }}}" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${PR:-${{ github.run_id }}}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Download checkpoint artifact
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
-          name: checkpoints-${{ steps.ckpt.outputs.run_id }}
+          name: checkpoints-pr-${{ steps.ckpt.outputs.pr_number }}
           path: ./checkpoints
 
       - name: Run automated review
         env:
-          CHECKPOINT_RUN_ID: ${{ steps.ckpt.outputs.run_id }}
+          CHECKPOINT_RUN_ID: pr-${{ steps.ckpt.outputs.pr_number }}
           GITHUB_TOKEN: ${{ secrets.AI_PR_TOKEN || secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL }}
@@ -58,7 +58,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: checkpoints-${{ steps.ckpt.outputs.run_id }}
+          name: checkpoints-pr-${{ steps.ckpt.outputs.pr_number }}
           path: ./checkpoints
           if-no-files-found: ignore
           overwrite: true

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
   contents: read
   issues: write
-  actions: read
+  actions: write
 
 jobs:
   review:
@@ -21,8 +21,30 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Resolve PR number for checkpoint
+        id: ckpt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "run_id=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            BRANCH="${{ github.ref_name }}"
+            PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+            echo "run_id=pr-${PR:-${{ github.run_id }}}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download checkpoint artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: checkpoints-${{ steps.ckpt.outputs.run_id }}
+          path: ./checkpoints
+
       - name: Run automated review
         env:
+          CHECKPOINT_RUN_ID: ${{ steps.ckpt.outputs.run_id }}
           GITHUB_TOKEN: ${{ secrets.AI_PR_TOKEN || secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL }}
@@ -31,3 +53,12 @@ jobs:
           GROQ_MODEL: ${{ vars.GROQ_MODEL }}
           GROQ_API_URL: ${{ vars.GROQ_API_URL }}
         run: node scripts/pr_review.mjs
+
+      - name: Upload checkpoint artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkpoints-${{ steps.ckpt.outputs.run_id }}
+          path: ./checkpoints
+          if-no-files-found: ignore
+          overwrite: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,14 @@ jobs:
         with:
           node-version: "20"
       - run: node --test scripts/tests/*.test.mjs
+
+      - name: Check checkpoint coverage (≥80%)
+        run: |
+          npx --yes c8 \
+            --include 'scripts/lib/checkpoint.mjs' \
+            --check-coverage \
+            --lines 80 \
+            --branches 80 \
+            --functions 80 \
+            --statements 80 \
+            node --test scripts/tests/checkpoint.test.mjs

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -22,9 +22,17 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Download checkpoint artifact
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: checkpoints-issue-${{ github.event.issue.number }}
+          path: ./checkpoints
+
       - name: Validate issue
         id: validate
         env:
+          CHECKPOINT_RUN_ID: issue-${{ github.event.issue.number }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
@@ -60,4 +68,14 @@ jobs:
           gh workflow run code-generation.yml \
             --repo "${{ github.repository }}" \
             --ref "${{ github.event.repository.default_branch }}" \
-            -f issue_number=${{ github.event.issue.number }}
+            -f issue_number=${{ github.event.issue.number }} \
+            -f validate_run_id=${{ github.run_id }}
+
+      - name: Upload checkpoint artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkpoints-issue-${{ github.event.issue.number }}
+          path: ./checkpoints
+          if-no-files-found: ignore
+          overwrite: true

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -60,6 +60,15 @@ jobs:
           IS_VALID: ${{ steps.validate.outputs.valid }}
         run: node scripts/manage_labels.mjs
 
+      - name: Upload checkpoint artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkpoints-issue-${{ github.event.issue.number }}
+          path: ./checkpoints
+          if-no-files-found: ignore
+          overwrite: true
+
       - name: Trigger Code Generation
         if: steps.validate.outputs.valid == 'true'
         env:
@@ -70,12 +79,3 @@ jobs:
             --ref "${{ github.event.repository.default_branch }}" \
             -f issue_number=${{ github.event.issue.number }} \
             -f validate_run_id=${{ github.run_id }}
-
-      - name: Upload checkpoint artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: checkpoints-issue-${{ github.event.issue.number }}
-          path: ./checkpoints
-          if-no-files-found: ignore
-          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 .env.local
 *.log
+checkpoints/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env.local
 *.log
 checkpoints/
+coverage/

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -150,6 +150,41 @@ logEnd('llm-call', 'ok');
 
 The config validation logic must have a minimum test coverage of 80%. This ensures that all critical paths are properly tested and validated before deployment.
 
+## Checkpoint Resume
+
+Critical job outputs are persisted to `./checkpoints/<runId>/<step>.json` via `scripts/lib/checkpoint.mjs` and exchanged between jobs as GitHub Actions artifacts. This allows a re-triggered run to resume from the last successful step rather than starting from scratch.
+
+### RunId naming conventions
+
+| Workflow chain | RunId format | Artifact name |
+|---|---|---|
+| `validate-issue` → `code-generation` | `issue-<number>` | `checkpoints-issue-<number>` |
+| `pr-review` → `auto-fix-pr` | `pr-<number>` | `checkpoints-pr-<number>` |
+
+The `CHECKPOINT_RUN_ID` environment variable overrides the default; each script falls back to deriving the ID from `ISSUE_NUMBER` or the resolved PR number if the variable is absent.
+
+### Step names written per job
+
+| Job script | Step name | Persisted fields |
+|---|---|---|
+| `validate_issue.mjs` | `validate` | `valid`, `score` |
+| `generate_issue_change.mjs` | `generate` | `summary`, `outputPaths` |
+| `pr_review.mjs` | `review` | `isApproved`, `prNumber` |
+| `auto_fix_pr.mjs` | `autofix` | `prNumber`, `attempt`, `outputPaths` |
+
+### Prerequisite enforcement
+
+`code-generation` (when triggered by the automated pipeline via `validate_run_id` dispatch input) and `auto-fix-pr` both fail explicitly with `::error::` if the expected upstream checkpoint file is not present, preventing execution in an incoherent state.
+
+### Cross-workflow artifact download
+
+- `validate-issue` passes its `GITHUB_RUN_ID` as the `validate_run_id` workflow-dispatch input when triggering `code-generation`. The generate job uses this run-id to download the artifact.
+- `auto-fix-pr` uses `gh run list` to find the latest successful `pr-review.yml` run for the PR branch and downloads its artifact by run-id.
+
+### Artifact retention
+
+GitHub Actions artifact retention applies (default 90 days). Old checkpoint artifacts for the same issue or PR number are overwritten (`overwrite: true`) on each new run.
+
 ## Startup Fail-Fast Validation (automation entrypoints)
 
 Automation scripts must fail before network calls when required startup inputs are invalid:

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -185,6 +185,10 @@ The `CHECKPOINT_RUN_ID` environment variable overrides the default; each script 
 
 GitHub Actions artifact retention applies (default 90 days). Old checkpoint artifacts for the same issue or PR number are overwritten (`overwrite: true`) on each new run.
 
+### Test coverage requirement
+
+`scripts/lib/checkpoint.mjs` and all code paths that call `writeCheckpoint`/`readCheckpoint` must maintain **≥ 80% test coverage**. Every distinct failure branch (e.g. ENOENT vs non-ENOENT in `readCheckpoint`, `mkdir` propagation in `writeCheckpoint`) must have a dedicated test case.
+
 ## Startup Fail-Fast Validation (automation entrypoints)
 
 Automation scripts must fail before network calls when required startup inputs are invalid:

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -148,7 +148,10 @@ logEnd('llm-call', 'ok');
 
 ## Minimum Test Coverage Policy
 
-The config validation logic must have a minimum test coverage of 80%. This ensures that all critical paths are properly tested and validated before deployment.
+The following modules must maintain **≥ 80% test coverage**, enforced in CI by `test.yml` via `c8 --check-coverage`:
+
+- **Config validation logic** (`scripts/lib/config.mjs`): ≥ 80% across all metrics.
+- **Checkpoint resume** (`scripts/lib/checkpoint.mjs`): ≥ 80% across statements, branches, functions, and lines. Every distinct failure branch (ENOENT vs non-ENOENT in `readCheckpoint`, `mkdir` propagation in `writeCheckpoint`) must have a dedicated test case.
 
 ## Checkpoint Resume
 

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -9,6 +9,7 @@ import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
 import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
 import { log, error as logError, setLogContext, logStart, logEnd, logSummary } from './lib/logger.mjs';
 import { retryWithBackoff } from './lib/retry.mjs';
+import { writeCheckpoint } from './lib/checkpoint.mjs';
 import { randomUUID } from 'node:crypto';
 
 process.on('unhandledRejection', (reason) => {
@@ -335,4 +336,7 @@ if (process.env.GITHUB_OUTPUT) {
   );
 }
 
+const checkpointRunId = process.env.CHECKPOINT_RUN_ID ?? `pr-${prNumber}`;
+await writeCheckpoint(checkpointRunId, 'autofix', { prNumber, attempt: nextAttempt, outputPaths });
+log('Checkpoint written', { runId: checkpointRunId, step: 'autofix' });
 log('Auto-fix complete', { prNumber, attempt: nextAttempt, paths: outputPaths.join(', ') });

--- a/scripts/generate_issue_change.mjs
+++ b/scripts/generate_issue_change.mjs
@@ -6,6 +6,7 @@ import { loadPrompt } from './lib/prompts.mjs';
 import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 import { buildFileContentsBlock } from './lib/file_injector.mjs';
+import { writeCheckpoint } from './lib/checkpoint.mjs';
 import fs from 'node:fs/promises';
 
 process.on('unhandledRejection', (reason) => {
@@ -54,6 +55,10 @@ async function main() {
 
   log('Wrote generated changes', { paths: outputPaths.join(', ') });
   log('Exported workflow outputs: summary, generated_paths');
+
+  const runId = process.env.CHECKPOINT_RUN_ID ?? `issue-${process.env.ISSUE_NUMBER ?? 'unknown'}`;
+  await writeCheckpoint(runId, 'generate', { summary, outputPaths });
+  log('Checkpoint written', { runId, step: 'generate' });
 }
 
 main().catch((err) => {

--- a/scripts/lib/checkpoint.mjs
+++ b/scripts/lib/checkpoint.mjs
@@ -1,0 +1,25 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const CHECKPOINT_BASE = path.resolve('./checkpoints');
+
+export async function writeCheckpoint(runId, step, data) {
+  const dir = path.join(CHECKPOINT_BASE, String(runId));
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, `${step}.json`),
+    JSON.stringify({ step, timestamp: new Date().toISOString(), data }, null, 2),
+    'utf8',
+  );
+}
+
+export async function readCheckpoint(runId, step) {
+  const file = path.join(CHECKPOINT_BASE, String(runId), `${step}.json`);
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  }
+}

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -8,6 +8,7 @@ import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 import { retryWithBackoff } from './lib/retry.mjs';
 import { buildAutomationGateContext } from './lib/coverage_checker.mjs';
+import { writeCheckpoint } from './lib/checkpoint.mjs';
 
 process.on('unhandledRejection', (reason) => {
   const err = reason instanceof Error ? reason : new Error(String(reason));
@@ -271,3 +272,7 @@ if (!isApproved) {
 await addLabel(apply);
 await removeLabel(remove);
 log('PR review labels applied', { prNumber, added: apply, removed: remove });
+
+const checkpointRunId = process.env.CHECKPOINT_RUN_ID ?? `pr-${prNumber}`;
+await writeCheckpoint(checkpointRunId, 'review', { isApproved, prNumber });
+log('Checkpoint written', { runId: checkpointRunId, step: 'review' });

--- a/scripts/tests/checkpoint.test.mjs
+++ b/scripts/tests/checkpoint.test.mjs
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { writeCheckpoint, readCheckpoint } from '../lib/checkpoint.mjs';
+
+test('writeCheckpoint creates directory scoped to runId', async (t) => {
+  const dirs = [];
+  t.mock.method(fs, 'mkdir', async (p) => { dirs.push(p); });
+  t.mock.method(fs, 'writeFile', async () => {});
+
+  await writeCheckpoint('issue-42', 'validate', {});
+
+  assert.ok(dirs.some((d) => d.includes('issue-42')));
+});
+
+test('writeCheckpoint writes step JSON to <runId>/<step>.json', async (t) => {
+  let writtenPath, writtenContent;
+  t.mock.method(fs, 'mkdir', async () => {});
+  t.mock.method(fs, 'writeFile', async (p, c) => { writtenPath = p; writtenContent = c; });
+
+  await writeCheckpoint('run-1', 'validate', { valid: true, score: 9 });
+
+  assert.ok(writtenPath.includes('run-1'));
+  assert.ok(writtenPath.endsWith('validate.json'));
+  const parsed = JSON.parse(writtenContent);
+  assert.equal(parsed.step, 'validate');
+  assert.deepEqual(parsed.data, { valid: true, score: 9 });
+});
+
+test('writeCheckpoint includes ISO timestamp in written JSON', async (t) => {
+  let writtenContent;
+  t.mock.method(fs, 'mkdir', async () => {});
+  t.mock.method(fs, 'writeFile', async (_, c) => { writtenContent = c; });
+
+  const before = new Date().toISOString();
+  await writeCheckpoint('run-1', 'generate', { outputPaths: ['a.js'] });
+  const after = new Date().toISOString();
+
+  const parsed = JSON.parse(writtenContent);
+  assert.ok(typeof parsed.timestamp === 'string');
+  assert.ok(parsed.timestamp >= before && parsed.timestamp <= after);
+});
+
+test('writeCheckpoint converts numeric runId to string in path', async (t) => {
+  let writtenPath;
+  t.mock.method(fs, 'mkdir', async () => {});
+  t.mock.method(fs, 'writeFile', async (p) => { writtenPath = p; });
+
+  await writeCheckpoint(42, 'review', {});
+
+  assert.ok(writtenPath.includes('42'));
+});
+
+test('writeCheckpoint propagates mkdir errors', async (t) => {
+  const err = Object.assign(new Error('disk full'), { code: 'ENOSPC' });
+  t.mock.method(fs, 'mkdir', async () => { throw err; });
+
+  await assert.rejects(() => writeCheckpoint('run-1', 'validate', {}), { code: 'ENOSPC' });
+});
+
+test('readCheckpoint returns parsed JSON on success', async (t) => {
+  const stored = { step: 'validate', timestamp: '2025-01-01T00:00:00.000Z', data: { valid: true } };
+  t.mock.method(fs, 'readFile', async () => JSON.stringify(stored));
+
+  const result = await readCheckpoint('run-1', 'validate');
+  assert.deepEqual(result, stored);
+});
+
+test('readCheckpoint returns null when file does not exist', async (t) => {
+  const err = Object.assign(new Error('ENOENT: no such file'), { code: 'ENOENT' });
+  t.mock.method(fs, 'readFile', async () => { throw err; });
+
+  const result = await readCheckpoint('run-1', 'missing');
+  assert.equal(result, null);
+});
+
+test('readCheckpoint rethrows non-ENOENT errors', async (t) => {
+  const err = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+  t.mock.method(fs, 'readFile', async () => { throw err; });
+
+  await assert.rejects(() => readCheckpoint('run-1', 'validate'), { code: 'EACCES' });
+});
+
+test('readCheckpoint reads path scoped to runId and step', async (t) => {
+  let readPath;
+  t.mock.method(fs, 'readFile', async (p) => { readPath = p; return '{}'; });
+
+  await readCheckpoint('pr-7', 'review');
+
+  assert.ok(readPath.includes('pr-7'));
+  assert.ok(readPath.endsWith('review.json'));
+});

--- a/scripts/validate_issue.mjs
+++ b/scripts/validate_issue.mjs
@@ -4,6 +4,7 @@ import { validateIssue, VALIDATION_SYSTEM_PROMPT, formatGitHubComment } from './
 import { callLLM } from './lib/llm_client.mjs';
 import { requireEnv, loadLLMConfig } from './lib/config.mjs';
 import { log, error as logError } from './lib/logger.mjs';
+import { writeCheckpoint } from './lib/checkpoint.mjs';
 import fs from 'node:fs/promises';
 
 process.on('unhandledRejection', (reason) => {
@@ -40,6 +41,10 @@ async function main() {
     await fs.appendFile(process.env.GITHUB_OUTPUT, output, 'utf8');
     log('Exported workflow outputs: valid, score, comment');
   }
+
+  const runId = process.env.CHECKPOINT_RUN_ID ?? `issue-${issueNumber}`;
+  await writeCheckpoint(runId, 'validate', { valid: result.valid, score: result.score });
+  log('Checkpoint written', { runId, step: 'validate' });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
- Add scripts/lib/checkpoint.mjs: writeCheckpoint(runId, step, data) and
  readCheckpoint(runId, step) persisting JSON under ./checkpoints/<runId>/

- Each job script writes a checkpoint before terminating:
  validate_issue → 'validate', generate_issue_change → 'generate',
  pr_review → 'review', auto_fix_pr → 'autofix'.
  runId defaults to CHECKPOINT_RUN_ID env var, falling back to
  issue-<ISSUE_NUMBER> or pr-<prNumber> from available context.

- validate-issue.yml: download artifact (continue-on-error) + upload at end;
  passes validate_run_id=$GITHUB_RUN_ID when triggering code-generation.

- code-generation.yml: accepts validate_run_id dispatch input; downloads
  checkpoint artifact from that run; fails with explicit error if validate
  checkpoint is missing (skipped for workflow_dispatch without validate_run_id).

- pr-review.yml: resolves PR number for a stable artifact key
  (checkpoints-pr-<N>); download (continue-on-error) + upload at end.

- auto-fix-pr.yml: uses gh CLI to find the latest successful pr-review run
  for the branch; downloads its artifact; fails with explicit error if the
  review checkpoint is missing; uploads updated artifact at end.