### PR TITLE
feat(metrics): add pipeline performance metrics system

### DIFF
--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -98,6 +98,10 @@ jobs:
             exit 1
           fi
 
+      - name: Capture metrics baseline
+        id: mbl
+        run: echo "count=$(wc -l < metrics/runs.jsonl 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
+
       - name: Apply AI fixes
         id: fix
         env:
@@ -120,6 +124,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
+          git reset HEAD -- metrics/
           git diff --staged --quiet || git commit -m "fix(ai): auto-fix attempt ${ATTEMPT}"
           git push origin HEAD:"${PR_BRANCH}"
 
@@ -131,3 +136,23 @@ jobs:
           path: ./checkpoints
           if-no-files-found: ignore
           overwrite: true
+
+      - name: Commit metrics
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASELINE: ${{ steps.mbl.outputs.count }}
+        run: |
+          NEW_LINES=$(tail -n +$((BASELINE + 1)) metrics/runs.jsonl 2>/dev/null || true)
+          [ -z "$NEW_LINES" ] && exit 0
+          for i in 1 2 3; do
+            RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
+            SHA=$(echo "$RESP" | jq -r '.sha // empty')
+            CURRENT=$(echo "$RESP" | jq -r '.content // ""' | tr -d '\n' | base64 -d 2>/dev/null || true)
+            NEW_B64=$(printf "%s" "${CURRENT}${NEW_LINES}"$'\n' | base64 -w0)
+            jq -nc --arg m "metrics: pr ${{ github.event.pull_request.number || github.event.issue.number }} auto-fix [skip ci]" \
+              --arg c "$NEW_B64" --arg s "$SHA" \
+              '{message:$m,content:$c}+if $s!="" then {sha:$s} else {} end' \
+              | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
+              && break || sleep $((2**i))
+          done

--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -145,6 +145,7 @@ jobs:
         run: |
           NEW_LINES=$(tail -n +$((BASELINE + 1)) metrics/runs.jsonl 2>/dev/null || true)
           [ -z "$NEW_LINES" ] && exit 0
+          UPLOADED=0
           for i in 1 2 3; do
             RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
             SHA=$(echo "$RESP" | jq -r '.sha // empty')
@@ -154,5 +155,6 @@ jobs:
               --arg c "$NEW_B64" --arg s "$SHA" \
               '{message:$m,content:$c}+if $s!="" then {sha:$s} else {} end' \
               | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
-              && break || sleep $((2**i))
+              && { UPLOADED=1; break; } || sleep $((2**i))
           done
+          [ "$UPLOADED" -eq 1 ] || { echo "::error::Failed to commit metrics after 3 attempts"; exit 1; }

--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -115,6 +115,15 @@ jobs:
           GROQ_API_URL: ${{ vars.GROQ_API_URL }}
         run: node scripts/auto_fix_pr.mjs
 
+      - name: Upload checkpoint artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkpoints-pr-${{ github.event.pull_request.number || github.event.issue.number }}
+          path: ./checkpoints
+          if-no-files-found: ignore
+          overwrite: true
+
       - name: Commit and push fixes
         if: steps.fix.outputs.fixed_paths != ''
         env:
@@ -127,15 +136,6 @@ jobs:
           git reset HEAD -- metrics/
           git diff --staged --quiet || git commit -m "fix(ai): auto-fix attempt ${ATTEMPT}"
           git push origin HEAD:"${PR_BRANCH}"
-
-      - name: Upload checkpoint artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: checkpoints-pr-${{ github.event.pull_request.number || github.event.issue.number }}
-          path: ./checkpoints
-          if-no-files-found: ignore
-          overwrite: true
 
       - name: Commit metrics
         if: always()

--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -158,4 +158,4 @@ jobs:
               | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
               && { UPLOADED=1; break; } || sleep $((2**i))
           done
-          [ "$UPLOADED" -eq 1 ] || { echo "::error::Failed to commit metrics after 3 attempts"; exit 1; }
+          [ "$UPLOADED" -eq 1 ] || echo "::warning::Failed to commit metrics after 3 attempts; data may be lost"

--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -150,6 +150,7 @@ jobs:
             RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
             SHA=$(echo "$RESP" | jq -r '.sha // empty')
             CURRENT=$(echo "$RESP" | jq -r '.content // ""' | tr -d '\n' | base64 -d 2>/dev/null || true)
+            [ -n "$CURRENT" ] && CURRENT="${CURRENT}"$'\n'
             NEW_B64=$(printf "%s" "${CURRENT}${NEW_LINES}"$'\n' | base64 -w0)
             jq -nc --arg m "metrics: pr ${{ github.event.pull_request.number || github.event.issue.number }} auto-fix [skip ci]" \
               --arg c "$NEW_B64" --arg s "$SHA" \

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -88,4 +88,4 @@ jobs:
               | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
               && { UPLOADED=1; break; } || sleep $((2**i))
           done
-          [ "$UPLOADED" -eq 1 ] || { echo "::error::Failed to commit metrics after 3 attempts"; exit 1; }
+          [ "$UPLOADED" -eq 1 ] || echo "::warning::Failed to commit metrics after 3 attempts; data may be lost"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -40,16 +40,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH="${{ github.event.pull_request.head.ref }}"
-          else
-            BRANCH="${{ github.ref_name }}"
-          fi
           RUN_ID=$(gh run list \
             --repo "${{ github.repository }}" \
             --workflow auto-fix-pr.yml \
-            --branch "$BRANCH" \
             --status completed \
+            --limit 20 \
             --json databaseId,conclusion \
             --jq '[.[] | select(.conclusion == "success")] | .[0].databaseId // ""' 2>/dev/null || echo "")
           echo "id=${RUN_ID}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -35,11 +35,33 @@ jobs:
             echo "pr_number=${PR:-${{ github.run_id }}}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Find latest auto-fix run for checkpoint
+        id: fix_run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          else
+            BRANCH="${{ github.ref_name }}"
+          fi
+          RUN_ID=$(gh run list \
+            --repo "${{ github.repository }}" \
+            --workflow auto-fix-pr.yml \
+            --branch "$BRANCH" \
+            --status completed \
+            --json databaseId,conclusion \
+            --jq '[.[] | select(.conclusion == "success")] | .[0].databaseId // ""' 2>/dev/null || echo "")
+          echo "id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
       - name: Download checkpoint artifact
+        if: steps.fix_run.outputs.id != ''
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: checkpoints-pr-${{ steps.ckpt.outputs.pr_number }}
+          run-id: ${{ steps.fix_run.outputs.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ./checkpoints
 
       - name: Capture metrics baseline

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -40,13 +40,28 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          else
+            BRANCH="${{ github.ref_name }}"
+          fi
           RUN_ID=$(gh run list \
             --repo "${{ github.repository }}" \
             --workflow auto-fix-pr.yml \
+            --branch "$BRANCH" \
             --status completed \
             --limit 20 \
             --json databaseId,conclusion \
             --jq '[.[] | select(.conclusion == "success")] | .[0].databaseId // ""' 2>/dev/null || echo "")
+          if [ -z "$RUN_ID" ]; then
+            RUN_ID=$(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow auto-fix-pr.yml \
+              --status completed \
+              --limit 20 \
+              --json databaseId,conclusion \
+              --jq '[.[] | select(.conclusion == "success")] | .[0].databaseId // ""' 2>/dev/null || echo "")
+          fi
           echo "id=${RUN_ID}" >> "$GITHUB_OUTPUT"
 
       - name: Download checkpoint artifact

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -80,6 +80,7 @@ jobs:
             RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
             SHA=$(echo "$RESP" | jq -r '.sha // empty')
             CURRENT=$(echo "$RESP" | jq -r '.content // ""' | tr -d '\n' | base64 -d 2>/dev/null || true)
+            [ -n "$CURRENT" ] && CURRENT="${CURRENT}"$'\n'
             NEW_B64=$(printf "%s" "${CURRENT}${NEW_LINES}"$'\n' | base64 -w0)
             jq -nc --arg m "metrics: pr ${{ steps.ckpt.outputs.pr_number }} [skip ci]" \
               --arg c "$NEW_B64" --arg s "$SHA" \

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
+  contents: write
   issues: write
   actions: write
 
@@ -42,6 +42,10 @@ jobs:
           name: checkpoints-pr-${{ steps.ckpt.outputs.pr_number }}
           path: ./checkpoints
 
+      - name: Capture metrics baseline
+        id: mbl
+        run: echo "count=$(wc -l < metrics/runs.jsonl 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
+
       - name: Run automated review
         env:
           CHECKPOINT_RUN_ID: pr-${{ steps.ckpt.outputs.pr_number }}
@@ -62,3 +66,23 @@ jobs:
           path: ./checkpoints
           if-no-files-found: ignore
           overwrite: true
+
+      - name: Commit metrics
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASELINE: ${{ steps.mbl.outputs.count }}
+        run: |
+          NEW_LINES=$(tail -n +$((BASELINE + 1)) metrics/runs.jsonl 2>/dev/null || true)
+          [ -z "$NEW_LINES" ] && exit 0
+          for i in 1 2 3; do
+            RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
+            SHA=$(echo "$RESP" | jq -r '.sha // empty')
+            CURRENT=$(echo "$RESP" | jq -r '.content // ""' | tr -d '\n' | base64 -d 2>/dev/null || true)
+            NEW_B64=$(printf "%s" "${CURRENT}${NEW_LINES}"$'\n' | base64 -w0)
+            jq -nc --arg m "metrics: pr ${{ steps.ckpt.outputs.pr_number }} [skip ci]" \
+              --arg c "$NEW_B64" --arg s "$SHA" \
+              '{message:$m,content:$c}+if $s!="" then {sha:$s} else {} end' \
+              | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
+              && break || sleep $((2**i))
+          done

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -75,6 +75,7 @@ jobs:
         run: |
           NEW_LINES=$(tail -n +$((BASELINE + 1)) metrics/runs.jsonl 2>/dev/null || true)
           [ -z "$NEW_LINES" ] && exit 0
+          UPLOADED=0
           for i in 1 2 3; do
             RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
             SHA=$(echo "$RESP" | jq -r '.sha // empty')
@@ -84,5 +85,6 @@ jobs:
               --arg c "$NEW_B64" --arg s "$SHA" \
               '{message:$m,content:$c}+if $s!="" then {sha:$s} else {} end' \
               | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
-              && break || sleep $((2**i))
+              && { UPLOADED=1; break; } || sleep $((2**i))
           done
+          [ "$UPLOADED" -eq 1 ] || { echo "::error::Failed to commit metrics after 3 attempts"; exit 1; }

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -94,7 +94,7 @@ jobs:
               | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
               && { UPLOADED=1; break; } || sleep $((2**i))
           done
-          [ "$UPLOADED" -eq 1 ] || { echo "::error::Failed to commit metrics after 3 attempts"; exit 1; }
+          [ "$UPLOADED" -eq 1 ] || echo "::warning::Failed to commit metrics after 3 attempts; data may be lost"
 
       - name: Trigger Code Generation
         if: steps.validate.outputs.valid == 'true'

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited]
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   actions: write
 
@@ -28,6 +28,10 @@ jobs:
         with:
           name: checkpoints-issue-${{ github.event.issue.number }}
           path: ./checkpoints
+
+      - name: Capture metrics baseline
+        id: mbl
+        run: echo "count=$(wc -l < metrics/runs.jsonl 2>/dev/null || echo 0)" >> "$GITHUB_OUTPUT"
 
       - name: Validate issue
         id: validate
@@ -68,6 +72,26 @@ jobs:
           path: ./checkpoints
           if-no-files-found: ignore
           overwrite: true
+
+      - name: Commit metrics
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASELINE: ${{ steps.mbl.outputs.count }}
+        run: |
+          NEW_LINES=$(tail -n +$((BASELINE + 1)) metrics/runs.jsonl 2>/dev/null || true)
+          [ -z "$NEW_LINES" ] && exit 0
+          for i in 1 2 3; do
+            RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
+            SHA=$(echo "$RESP" | jq -r '.sha // empty')
+            CURRENT=$(echo "$RESP" | jq -r '.content // ""' | tr -d '\n' | base64 -d 2>/dev/null || true)
+            NEW_B64=$(printf "%s" "${CURRENT}${NEW_LINES}"$'\n' | base64 -w0)
+            jq -nc --arg m "metrics: issue ${{ github.event.issue.number }} [skip ci]" \
+              --arg c "$NEW_B64" --arg s "$SHA" \
+              '{message:$m,content:$c}+if $s!="" then {sha:$s} else {} end' \
+              | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
+              && break || sleep $((2**i))
+          done
 
       - name: Trigger Code Generation
         if: steps.validate.outputs.valid == 'true'

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           NEW_LINES=$(tail -n +$((BASELINE + 1)) metrics/runs.jsonl 2>/dev/null || true)
           [ -z "$NEW_LINES" ] && exit 0
+          UPLOADED=0
           for i in 1 2 3; do
             RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
             SHA=$(echo "$RESP" | jq -r '.sha // empty')
@@ -90,8 +91,9 @@ jobs:
               --arg c "$NEW_B64" --arg s "$SHA" \
               '{message:$m,content:$c}+if $s!="" then {sha:$s} else {} end' \
               | gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" -X PUT --input - \
-              && break || sleep $((2**i))
+              && { UPLOADED=1; break; } || sleep $((2**i))
           done
+          [ "$UPLOADED" -eq 1 ] || { echo "::error::Failed to commit metrics after 3 attempts"; exit 1; }
 
       - name: Trigger Code Generation
         if: steps.validate.outputs.valid == 'true'

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -86,6 +86,7 @@ jobs:
             RESP=$(gh api "repos/$GITHUB_REPOSITORY/contents/metrics/runs.jsonl" 2>/dev/null || echo '{}')
             SHA=$(echo "$RESP" | jq -r '.sha // empty')
             CURRENT=$(echo "$RESP" | jq -r '.content // ""' | tr -d '\n' | base64 -d 2>/dev/null || true)
+            [ -n "$CURRENT" ] && CURRENT="${CURRENT}"$'\n'
             NEW_B64=$(printf "%s" "${CURRENT}${NEW_LINES}"$'\n' | base64 -w0)
             jq -nc --arg m "metrics: issue ${{ github.event.issue.number }} [skip ci]" \
               --arg c "$NEW_B64" --arg s "$SHA" \

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,5 +1,37 @@
 # Operator Runbook — Failure Triage
 
+## Metrics System
+
+Pipeline performance is recorded to `metrics/runs.jsonl` (append-only JSONL, one record per completed run). Each record is committed to the default branch via the GitHub Contents API by the respective workflow step.
+
+**Record types:**
+
+| `type` | Written by | When |
+|--------|-----------|------|
+| `issue` | `validate-issue.yml` | After every issue validation (APPROVE or MANUAL) |
+| `pr` | `pr-review.yml` | When PR verdict is APPROVE |
+| `pr` | `auto-fix-pr.yml` | When auto-fix attempt limit is exhausted (verdict MANUAL) |
+
+**Key fields — issue records:** `issue_number`, `verdict` (APPROVE/MANUAL), `score`, `started_at`, `ended_at`, `duration_ms`, `input_tokens_est`, `output_tokens_est`.
+
+**Key fields — PR records:** `pr_number`, `issue_number`, `final_verdict`, `review_cycles`, `request_changes_count`, `auto_fix_pushes`, `started_at`, `ended_at`, `total_input_tokens_est`, `total_output_tokens_est`.
+
+**Generate a markdown summary report:**
+```bash
+node scripts/metrics-report.mjs
+```
+
+**Metrics troubleshooting:**
+
+| Symptom | Probable Cause |
+|---------|----------------|
+| `metrics/runs.jsonl` not updating after runs | Workflow `contents: write` permission missing; or the GitHub Contents API call failed (check "Commit metrics" step logs) |
+| Cost/token totals seem too low | PR records use `total_input_tokens_est` / `total_output_tokens_est`; verify the report script is picking up both field names |
+| MANUAL verdict recorded but PR was actually approved | Auto-fix exhaustion ran in the same session as a later manual approval — the MANUAL record is correct for that snapshot; future APPROVE records will appear separately |
+| `metrics/runs.jsonl` has duplicate lines | Two concurrent workflow runs both succeeded in pushing — safe to deduplicate manually; JSONL lines are self-contained |
+
+---
+
 ## Symptom → Probable Cause Mapping
 
 | Symptom | Probable Cause |

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -10,7 +10,7 @@ import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/
 import { log, error as logError, setLogContext, logStart, logEnd, logSummary } from './lib/logger.mjs';
 import { retryWithBackoff } from './lib/retry.mjs';
 import { writeCheckpoint, readCheckpoint } from './lib/checkpoint.mjs';
-import { appendMetric, estimateTokens } from './lib/metrics.mjs';
+import { appendMetric } from './lib/metrics.mjs';
 import { randomUUID } from 'node:crypto';
 
 process.on('unhandledRejection', (reason) => {

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -10,7 +10,7 @@ import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/
 import { log, error as logError, setLogContext, logStart, logEnd, logSummary } from './lib/logger.mjs';
 import { retryWithBackoff } from './lib/retry.mjs';
 import { writeCheckpoint, readCheckpoint } from './lib/checkpoint.mjs';
-import { appendMetric } from './lib/metrics.mjs';
+import { appendMetric, estimateTokens } from './lib/metrics.mjs';
 import { randomUUID } from 'node:crypto';
 
 process.on('unhandledRejection', (reason) => {
@@ -34,10 +34,6 @@ const MODEL_CONTEXT_WINDOW = {
   'claude-sonnet-4-6': 200000,
   'claude-haiku-4-5-20251001': 200000,
 };
-
-function estimateTokens(text) {
-  return Math.ceil(text.length / 4);
-}
 
 function truncateToTokenBudget(text, tokenBudget) {
   if (tokenBudget <= 0) return '';

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -9,7 +9,8 @@ import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
 import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from './lib/output_writer.mjs';
 import { log, error as logError, setLogContext, logStart, logEnd, logSummary } from './lib/logger.mjs';
 import { retryWithBackoff } from './lib/retry.mjs';
-import { writeCheckpoint } from './lib/checkpoint.mjs';
+import { writeCheckpoint, readCheckpoint } from './lib/checkpoint.mjs';
+import { appendMetric, estimateTokens } from './lib/metrics.mjs';
 import { randomUUID } from 'node:crypto';
 
 process.on('unhandledRejection', (reason) => {
@@ -178,6 +179,27 @@ if (attemptCount >= MAX_ATTEMPTS) {
     body: JSON.stringify({ body: exhaustedBody }),
   });
   log('Max auto-fix attempts reached', { prNumber, attemptCount });
+
+  const exhaustedRunId = process.env.CHECKPOINT_RUN_ID ?? `pr-${prNumber}`;
+  const exhaustedMetricsCheckpoint = await readCheckpoint(exhaustedRunId, 'pr_metrics');
+  if (exhaustedMetricsCheckpoint?.data) {
+    const m = exhaustedMetricsCheckpoint.data;
+    await appendMetric({
+      type: 'pr',
+      pr_number: prNumber,
+      issue_number: m.issue_number,
+      final_verdict: 'MANUAL',
+      review_cycles: m.review_cycles,
+      request_changes_count: m.request_changes_count,
+      auto_fix_pushes: m.auto_fix_pushes,
+      started_at: m.started_at,
+      ended_at: new Date().toISOString(),
+      total_input_tokens_est: m.total_input_tokens_est,
+      total_output_tokens_est: m.total_output_tokens_est,
+    });
+    log('PR metrics recorded', { prNumber, verdict: 'MANUAL' });
+  }
+
   process.exit(0);
 }
 
@@ -339,4 +361,24 @@ if (process.env.GITHUB_OUTPUT) {
 const checkpointRunId = process.env.CHECKPOINT_RUN_ID ?? `pr-${prNumber}`;
 await writeCheckpoint(checkpointRunId, 'autofix', { prNumber, attempt: nextAttempt, outputPaths });
 log('Checkpoint written', { runId: checkpointRunId, step: 'autofix' });
+
+const prMetricsCheckpoint = await readCheckpoint(checkpointRunId, 'pr_metrics');
+const prMetrics = prMetricsCheckpoint?.data ?? {
+  pr_number: prNumber,
+  issue_number: null,
+  started_at: new Date().toISOString(),
+  request_changes_count: 0,
+  auto_fix_pushes: 0,
+  review_cycles: 0,
+  total_input_tokens_est: 0,
+  total_output_tokens_est: 0,
+};
+await writeCheckpoint(checkpointRunId, 'pr_metrics', {
+  ...prMetrics,
+  auto_fix_pushes: prMetrics.auto_fix_pushes + 1,
+  total_input_tokens_est: prMetrics.total_input_tokens_est + estimateTokens(systemPrompt + userPrompt),
+  total_output_tokens_est: prMetrics.total_output_tokens_est + estimateTokens(raw),
+});
+log('PR metrics checkpoint updated', { prNumber, auto_fix_pushes: prMetrics.auto_fix_pushes + 1 });
+
 log('Auto-fix complete', { prNumber, attempt: nextAttempt, paths: outputPaths.join(', ') });

--- a/scripts/lib/metrics.mjs
+++ b/scripts/lib/metrics.mjs
@@ -1,0 +1,27 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const METRICS_DIR = path.resolve('./metrics');
+const METRICS_FILE = path.join(METRICS_DIR, 'runs.jsonl');
+
+export function estimateTokens(text) {
+  return Math.ceil((text ?? '').length / 4);
+}
+
+export async function appendMetric(record) {
+  await fs.mkdir(METRICS_DIR, { recursive: true });
+  await fs.appendFile(METRICS_FILE, JSON.stringify(record) + '\n', 'utf8');
+}
+
+export async function readMetrics() {
+  try {
+    const raw = await fs.readFile(METRICS_FILE, 'utf8');
+    return raw
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+  } catch (err) {
+    if (err.code === 'ENOENT') return [];
+    throw err;
+  }
+}

--- a/scripts/lib/metrics.mjs
+++ b/scripts/lib/metrics.mjs
@@ -1,21 +1,24 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-const METRICS_DIR = path.resolve('./metrics');
-const METRICS_FILE = path.join(METRICS_DIR, 'runs.jsonl');
+function getMetricsFile() {
+  return process.env.METRICS_FILE ?? path.resolve('./metrics/runs.jsonl');
+}
 
 export function estimateTokens(text) {
   return Math.ceil((text ?? '').length / 4);
 }
 
 export async function appendMetric(record) {
-  await fs.mkdir(METRICS_DIR, { recursive: true });
-  await fs.appendFile(METRICS_FILE, JSON.stringify(record) + '\n', 'utf8');
+  const file = getMetricsFile();
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.appendFile(file, JSON.stringify(record) + '\n', 'utf8');
 }
 
 export async function readMetrics() {
+  const file = getMetricsFile();
   try {
-    const raw = await fs.readFile(METRICS_FILE, 'utf8');
+    const raw = await fs.readFile(file, 'utf8');
     return raw
       .split('\n')
       .filter((l) => l.trim())

--- a/scripts/metrics-report.mjs
+++ b/scripts/metrics-report.mjs
@@ -48,8 +48,10 @@ const avgPRDuration = prRecords.length
     })()
   : 'N/A';
 
-const totalInputTokens = records.reduce((s, r) => s + (r.input_tokens_est ?? 0), 0);
-const totalOutputTokens = records.reduce((s, r) => s + (r.output_tokens_est ?? 0), 0);
+const totalInputTokens = records.reduce(
+  (s, r) => s + (r.input_tokens_est ?? r.total_input_tokens_est ?? 0), 0);
+const totalOutputTokens = records.reduce(
+  (s, r) => s + (r.output_tokens_est ?? r.total_output_tokens_est ?? 0), 0);
 // Claude Sonnet 4.6: $3/MTok input, $15/MTok output
 const estimatedCost = (totalInputTokens * 3e-6 + totalOutputTokens * 15e-6).toFixed(4);
 

--- a/scripts/metrics-report.mjs
+++ b/scripts/metrics-report.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+import { readMetrics } from './lib/metrics.mjs';
+
+const records = await readMetrics();
+
+if (records.length === 0) {
+  console.log('# Metrics Report\n\n_No data recorded yet._');
+  process.exit(0);
+}
+
+const issueRecords = records.filter((r) => r.type === 'issue');
+const prRecords = records.filter((r) => r.type === 'pr');
+
+const approvedIssues = issueRecords.filter((r) => r.verdict === 'APPROVE');
+const manualIssues = issueRecords.filter((r) => r.verdict === 'MANUAL');
+
+const approvedPRs = prRecords.filter((r) => r.final_verdict === 'APPROVE');
+const manualPRs = prRecords.filter((r) => r.final_verdict === 'MANUAL');
+
+function pct(n, total) {
+  return total === 0 ? 'N/A' : `${((n / total) * 100).toFixed(1)}%`;
+}
+
+function avg(arr, key) {
+  if (!arr.length) return 'N/A';
+  return (arr.reduce((s, r) => s + (r[key] ?? 0), 0) / arr.length).toFixed(1);
+}
+
+function fmtMs(ms) {
+  if (ms == null) return 'N/A';
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+}
+
+const avgIssueDuration = issueRecords.length
+  ? fmtMs(issueRecords.reduce((s, r) => s + (r.duration_ms ?? 0), 0) / issueRecords.length)
+  : 'N/A';
+
+const avgPRDuration = prRecords.length
+  ? (() => {
+      const withDates = prRecords.filter((r) => r.started_at && r.ended_at);
+      if (!withDates.length) return 'N/A';
+      const ms = withDates.reduce((s, r) => s + (new Date(r.ended_at) - new Date(r.started_at)), 0);
+      return fmtMs(ms / withDates.length);
+    })()
+  : 'N/A';
+
+const totalInputTokens = records.reduce((s, r) => s + (r.input_tokens_est ?? 0), 0);
+const totalOutputTokens = records.reduce((s, r) => s + (r.output_tokens_est ?? 0), 0);
+// Claude Sonnet 4.6: $3/MTok input, $15/MTok output
+const estimatedCost = (totalInputTokens * 3e-6 + totalOutputTokens * 15e-6).toFixed(4);
+
+const avgCycles = avg(prRecords, 'review_cycles');
+const avgAutoFix = avg(prRecords, 'auto_fix_pushes');
+
+const verdictDist = {};
+for (const r of issueRecords) verdictDist[r.verdict] = (verdictDist[r.verdict] ?? 0) + 1;
+const prVerdictDist = {};
+for (const r of prRecords) prVerdictDist[r.final_verdict] = (prVerdictDist[r.final_verdict] ?? 0) + 1;
+
+const lines = [
+  `# Metrics Report`,
+  ``,
+  `Generated: ${new Date().toISOString()}  |  Total records: ${records.length}`,
+  ``,
+  `## Issue Validation`,
+  ``,
+  `| Metric | Value |`,
+  `|--------|-------|`,
+  `| Issues processed | ${issueRecords.length} |`,
+  `| Approved | ${approvedIssues.length} (${pct(approvedIssues.length, issueRecords.length)}) |`,
+  `| Manual intervention | ${manualIssues.length} (${pct(manualIssues.length, issueRecords.length)}) |`,
+  `| Avg validation time | ${avgIssueDuration} |`,
+  ``,
+  `## PR Reviews`,
+  ``,
+  `| Metric | Value |`,
+  `|--------|-------|`,
+  `| PRs completed | ${prRecords.length} |`,
+  `| Auto-approved | ${approvedPRs.length} (${pct(approvedPRs.length, prRecords.length)}) |`,
+  `| Manual intervention | ${manualPRs.length} (${pct(manualPRs.length, prRecords.length)}) |`,
+  `| Avg review cycles | ${avgCycles} |`,
+  `| Avg auto-fix pushes | ${avgAutoFix} |`,
+  `| Avg time to resolution | ${avgPRDuration} |`,
+  ``,
+  `## Token Usage & Estimated Cost`,
+  ``,
+  `| Metric | Value |`,
+  `|--------|-------|`,
+  `| Total input tokens (est.) | ${totalInputTokens.toLocaleString()} |`,
+  `| Total output tokens (est.) | ${totalOutputTokens.toLocaleString()} |`,
+  `| Estimated cost | $${estimatedCost} USD |`,
+  ``,
+  `> Cost estimate based on Claude Sonnet 4.6 pricing ($3/MTok input, $15/MTok output). Token counts are character-length estimates.`,
+  ``,
+  `## Verdict Distribution`,
+  ``,
+  `**Issues**`,
+  ``,
+  ...Object.entries(verdictDist).map(([v, n]) => `- ${v}: ${n} (${pct(n, issueRecords.length)})`),
+  ``,
+  `**PRs**`,
+  ``,
+  ...Object.entries(prVerdictDist).map(([v, n]) => `- ${v}: ${n} (${pct(n, prRecords.length)})`),
+];
+
+console.log(lines.join('\n'));

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -8,7 +8,15 @@ import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 import { retryWithBackoff } from './lib/retry.mjs';
 import { buildAutomationGateContext } from './lib/coverage_checker.mjs';
-import { writeCheckpoint } from './lib/checkpoint.mjs';
+import { writeCheckpoint, readCheckpoint } from './lib/checkpoint.mjs';
+import { appendMetric, estimateTokens } from './lib/metrics.mjs';
+
+const _reviewStartedAt = new Date().toISOString();
+
+function extractIssueNumber(text) {
+  const m = (text ?? '').match(/[Cc]loses?\s+#(\d+)/);
+  return m ? Number(m[1]) : null;
+}
 
 process.on('unhandledRejection', (reason) => {
   const err = reason instanceof Error ? reason : new Error(String(reason));
@@ -276,3 +284,43 @@ log('PR review labels applied', { prNumber, added: apply, removed: remove });
 const checkpointRunId = process.env.CHECKPOINT_RUN_ID ?? `pr-${prNumber}`;
 await writeCheckpoint(checkpointRunId, 'review', { isApproved, prNumber });
 log('Checkpoint written', { runId: checkpointRunId, step: 'review' });
+
+const prMetricsCheckpoint = await readCheckpoint(checkpointRunId, 'pr_metrics');
+const prMetrics = prMetricsCheckpoint?.data ?? {
+  pr_number: prNumber,
+  issue_number: extractIssueNumber(prBody),
+  started_at: _reviewStartedAt,
+  request_changes_count: 0,
+  auto_fix_pushes: 0,
+  review_cycles: 0,
+  total_input_tokens_est: 0,
+  total_output_tokens_est: 0,
+};
+
+const updatedPrMetrics = {
+  ...prMetrics,
+  review_cycles: prMetrics.review_cycles + 1,
+  request_changes_count: prMetrics.request_changes_count + (isApproved ? 0 : 1),
+  total_input_tokens_est: prMetrics.total_input_tokens_est + estimateTokens(systemPrompt + userPrompt),
+  total_output_tokens_est: prMetrics.total_output_tokens_est + estimateTokens(cleanReview),
+};
+
+await writeCheckpoint(checkpointRunId, 'pr_metrics', updatedPrMetrics);
+log('PR metrics checkpoint updated', { prNumber, review_cycles: updatedPrMetrics.review_cycles });
+
+if (isApproved) {
+  await appendMetric({
+    type: 'pr',
+    pr_number: prNumber,
+    issue_number: updatedPrMetrics.issue_number,
+    final_verdict: 'APPROVE',
+    review_cycles: updatedPrMetrics.review_cycles,
+    request_changes_count: updatedPrMetrics.request_changes_count,
+    auto_fix_pushes: updatedPrMetrics.auto_fix_pushes,
+    started_at: updatedPrMetrics.started_at,
+    ended_at: new Date().toISOString(),
+    total_input_tokens_est: updatedPrMetrics.total_input_tokens_est,
+    total_output_tokens_est: updatedPrMetrics.total_output_tokens_est,
+  });
+  log('PR metrics recorded', { prNumber, verdict: 'APPROVE' });
+}

--- a/scripts/tests/auto_fix_pr.test.mjs
+++ b/scripts/tests/auto_fix_pr.test.mjs
@@ -151,6 +151,7 @@ async function runAutoFix(port, eventFile, { extraEnv = {}, cwd = null } = {}) {
     GITHUB_EVENT_PATH: eventFile,
     GITHUB_API_URL: `http://127.0.0.1:${port}`,
     ANTHROPIC_API_URL: `http://127.0.0.1:${port}/v1/messages`,
+    METRICS_FILE: '/dev/null',
     ...extraEnv,
   };
   return new Promise((resolve) => {

--- a/scripts/tests/entrypoints.test.mjs
+++ b/scripts/tests/entrypoints.test.mjs
@@ -11,7 +11,7 @@ const SCRIPTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..'
 function runScript(scriptName, env = {}) {
   return new Promise((resolve) => {
     const child = spawn(process.execPath, [path.join(SCRIPTS_DIR, scriptName)], {
-      env: { PATH: process.env.PATH, ...env },
+      env: { PATH: process.env.PATH, METRICS_FILE: '/dev/null', ...env },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';

--- a/scripts/tests/github_output.test.mjs
+++ b/scripts/tests/github_output.test.mjs
@@ -53,6 +53,7 @@ test('validate_issue.mjs writes valid/score/comment to GITHUB_OUTPUT', async () 
       ISSUE_TITLE: 'Add login feature',
       ANTHROPIC_API_URL: `http://127.0.0.1:${port}/v1/messages`,
       GITHUB_OUTPUT: outputFile,
+      METRICS_FILE: '/dev/null',
     });
 
     assert.equal(result.code, 0, `expected exit 0, stderr: ${result.stderr}`);

--- a/scripts/tests/metrics.test.mjs
+++ b/scripts/tests/metrics.test.mjs
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import { appendMetric, readMetrics, estimateTokens } from '../lib/metrics.mjs';
+
+// --- estimateTokens ---
+
+test('estimateTokens returns ceil(length/4) for a regular string', () => {
+  assert.equal(estimateTokens('abcd'), 1);
+  assert.equal(estimateTokens('abcde'), 2);
+  assert.equal(estimateTokens('a'.repeat(12)), 3);
+});
+
+test('estimateTokens returns 0 for an empty string', () => {
+  assert.equal(estimateTokens(''), 0);
+});
+
+test('estimateTokens treats null/undefined as empty string', () => {
+  assert.equal(estimateTokens(null), 0);
+  assert.equal(estimateTokens(undefined), 0);
+});
+
+// --- appendMetric ---
+
+test('appendMetric creates the metrics directory', async (t) => {
+  const dirs = [];
+  t.mock.method(fs, 'mkdir', async (p) => { dirs.push(p); });
+  t.mock.method(fs, 'appendFile', async () => {});
+
+  await appendMetric({ type: 'issue', issue_number: 1 });
+
+  assert.ok(dirs.some((d) => d.endsWith('metrics')));
+});
+
+test('appendMetric writes a single JSON line followed by newline', async (t) => {
+  t.mock.method(fs, 'mkdir', async () => {});
+  let writtenContent;
+  t.mock.method(fs, 'appendFile', async (_p, c) => { writtenContent = c; });
+
+  const record = { type: 'issue', issue_number: 42, verdict: 'APPROVE' };
+  await appendMetric(record);
+
+  assert.ok(writtenContent.endsWith('\n'), 'line must end with newline');
+  assert.deepEqual(JSON.parse(writtenContent.trim()), record);
+});
+
+test('appendMetric writes to a file named runs.jsonl inside the metrics dir', async (t) => {
+  t.mock.method(fs, 'mkdir', async () => {});
+  let writtenPath;
+  t.mock.method(fs, 'appendFile', async (p) => { writtenPath = p; });
+
+  await appendMetric({ type: 'pr' });
+
+  assert.ok(String(writtenPath).endsWith('runs.jsonl'));
+  assert.ok(String(writtenPath).includes('metrics'));
+});
+
+test('appendMetric propagates appendFile errors', async (t) => {
+  t.mock.method(fs, 'mkdir', async () => {});
+  const err = Object.assign(new Error('disk full'), { code: 'ENOSPC' });
+  t.mock.method(fs, 'appendFile', async () => { throw err; });
+
+  await assert.rejects(() => appendMetric({ type: 'issue' }), { code: 'ENOSPC' });
+});
+
+// --- readMetrics ---
+
+test('readMetrics returns empty array when file does not exist', async (t) => {
+  const notFound = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+  t.mock.method(fs, 'readFile', async () => { throw notFound; });
+
+  const result = await readMetrics();
+  assert.deepEqual(result, []);
+});
+
+test('readMetrics parses every JSON line and returns them as objects', async (t) => {
+  const r1 = { type: 'issue', issue_number: 1 };
+  const r2 = { type: 'pr', pr_number: 5 };
+  t.mock.method(fs, 'readFile', async () => `${JSON.stringify(r1)}\n${JSON.stringify(r2)}\n`);
+
+  const result = await readMetrics();
+  assert.deepEqual(result, [r1, r2]);
+});
+
+test('readMetrics skips blank lines', async (t) => {
+  const r1 = { type: 'issue', issue_number: 3 };
+  t.mock.method(fs, 'readFile', async () => `\n${JSON.stringify(r1)}\n\n`);
+
+  const result = await readMetrics();
+  assert.deepEqual(result, [r1]);
+});
+
+test('readMetrics rethrows non-ENOENT errors', async (t) => {
+  const err = Object.assign(new Error('permission denied'), { code: 'EACCES' });
+  t.mock.method(fs, 'readFile', async () => { throw err; });
+
+  await assert.rejects(() => readMetrics(), { code: 'EACCES' });
+});

--- a/scripts/tests/pr_review.test.mjs
+++ b/scripts/tests/pr_review.test.mjs
@@ -136,6 +136,7 @@ async function runPrReview(port, eventFile, extraEnv = {}) {
     GITHUB_EVENT_PATH: eventFile,
     GITHUB_API_URL: `http://127.0.0.1:${port}`,
     ANTHROPIC_API_URL: `http://127.0.0.1:${port}/v1/messages`,
+    METRICS_FILE: '/dev/null',
     ...extraEnv,
   };
   return new Promise((resolve) => {

--- a/scripts/validate_issue.mjs
+++ b/scripts/validate_issue.mjs
@@ -5,6 +5,7 @@ import { callLLM } from './lib/llm_client.mjs';
 import { requireEnv, loadLLMConfig } from './lib/config.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 import { writeCheckpoint } from './lib/checkpoint.mjs';
+import { appendMetric, estimateTokens } from './lib/metrics.mjs';
 import fs from 'node:fs/promises';
 
 process.on('unhandledRejection', (reason) => {
@@ -14,6 +15,9 @@ process.on('unhandledRejection', (reason) => {
 });
 
 async function main() {
+  const startedAt = new Date().toISOString();
+  const startMs = Date.now();
+
   const issueNumber = requireEnv('ISSUE_NUMBER');
   const issueTitle = requireEnv('ISSUE_TITLE');
   const issueBody = (process.env.ISSUE_BODY || '').trim() || '(no body provided)';
@@ -45,6 +49,19 @@ async function main() {
   const runId = process.env.CHECKPOINT_RUN_ID ?? `issue-${issueNumber}`;
   await writeCheckpoint(runId, 'validate', { valid: result.valid, score: result.score });
   log('Checkpoint written', { runId, step: 'validate' });
+
+  await appendMetric({
+    type: 'issue',
+    issue_number: Number(issueNumber),
+    verdict: result.valid ? 'APPROVE' : 'MANUAL',
+    score: result.score,
+    started_at: startedAt,
+    ended_at: new Date().toISOString(),
+    duration_ms: Date.now() - startMs,
+    input_tokens_est: estimateTokens(VALIDATION_SYSTEM_PROMPT + issueTitle + issueBody),
+    output_tokens_est: estimateTokens(comment),
+  });
+  log('Metrics recorded', { issueNumber, verdict: result.valid ? 'APPROVE' : 'MANUAL' });
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Add append-only JSONL metrics to metrics/runs.jsonl, capturing:
- Per issue: verdict (APPROVE/MANUAL), score, timestamps, token estimates
- Per PR: review cycles, REQUEST_CHANGES count, auto-fix pushes, token totals

Write final PR record on APPROVE (pr_review.mjs) or when auto-fix is
exhausted (auto_fix_pr.mjs). Accumulate PR data across review cycles via
the existing checkpoint system. Add scripts/metrics-report.mjs to produce
a markdown summary (avg cycles, success rate, cost estimate, distributions).

Workflows commit the metrics file to the repo via GitHub Contents API to
avoid branch-context issues; retry up to 3 times on SHA conflict.

https://claude.ai/code/session_01B1p7v1WcxchrkJ86gitBEk