### PR TITLE
feat(output_writer): add JsonParseError and fence-first JSON parsing

### DIFF
--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -62,12 +62,23 @@ jobs:
           node-version: '20'
 
       - name: Download checkpoint artifact
-        uses: actions/download-artifact@v4
-        continue-on-error: true
-        with:
-          name: checkpoints-pr-${{ github.event.pull_request.number || github.event.issue.number }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: ./checkpoints
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          ARTIFACT_NAME="checkpoints-pr-${PR_NUMBER}"
+          ARTIFACT_URL=$(gh api \
+            "repos/${{ github.repository }}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=1" \
+            --jq '[.artifacts[] | select(.expired == false)] | .[0].archive_download_url // ""' \
+            2>/dev/null || echo "")
+          if [ -n "$ARTIFACT_URL" ]; then
+            mkdir -p ./checkpoints
+            curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" "${ARTIFACT_URL}" -o /tmp/checkpoint.zip
+            unzip -o /tmp/checkpoint.zip -d ./checkpoints/
+            rm -f /tmp/checkpoint.zip
+          else
+            echo "No checkpoint artifact found for ${ARTIFACT_NAME}"
+          fi
 
       - name: Check prerequisite checkpoint
         run: |

--- a/.github/workflows/auto-fix-pr.yml
+++ b/.github/workflows/auto-fix-pr.yml
@@ -61,32 +61,11 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Find latest PR review run for checkpoint
-        id: review_run
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BRANCH="${{ github.event.pull_request.head.ref }}"
-          else
-            BRANCH="${{ steps.pr.outputs.head_ref }}"
-          fi
-          RUN_ID=$(gh run list \
-            --repo "${{ github.repository }}" \
-            --workflow pr-review.yml \
-            --branch "$BRANCH" \
-            --status completed \
-            --json databaseId,conclusion \
-            --jq '[.[] | select(.conclusion == "success")] | .[0].databaseId // ""' 2>/dev/null || echo "")
-          echo "id=${RUN_ID}" >> "$GITHUB_OUTPUT"
-
       - name: Download checkpoint artifact
-        if: steps.review_run.outputs.id != ''
         uses: actions/download-artifact@v4
         continue-on-error: true
         with:
           name: checkpoints-pr-${{ github.event.pull_request.number || github.event.issue.number }}
-          run-id: ${{ steps.review_run.outputs.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: ./checkpoints
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -32,6 +32,10 @@ jobs:
           else
             BRANCH="${{ github.ref_name }}"
             PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+            if [ -z "$PR" ]; then
+              sleep 5
+              PR=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // ""' 2>/dev/null || echo "")
+            fi
             echo "pr_number=${PR:-${{ github.run_id }}}" >> "$GITHUB_OUTPUT"
           fi
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,11 @@ Any PR that adds a new exported function to `scripts/lib/` must include tests fo
 When reading and acting on review comments or inline threads on a pull request:
 
 1. **Fix the code** — implement the requested change and push the commit.
-2. **Reply to each thread** — for every inline review thread addressed, post a reply explaining what was changed and which commit contains the fix (e.g. "Fixed in `abc1234` — …").
+2. **Reply to each thread** — for every inline review thread addressed, post a reply explaining what was changed and which commit contains the fix (e.g. "Fixed in `abc1234` — …"). If no code change was needed (e.g. the comment was a false positive or already correct), explain why in the reply.
 3. **Resolve each thread** — after replying, mark the thread as resolved so reviewers can see at a glance what is still open.
-4. **Request a new review** — once all threads are resolved, post a PR comment with `@Codex review` to trigger the next automated review cycle.
+4. **Request a new review** — **only if at least one thread required an actual code fix** (i.e. a new commit was pushed): post a PR comment with `@Codex review` to trigger the next automated review cycle. If all threads were addressed with explanations only and no code was changed, do **not** post `@Codex review`.
 
-Do not resolve a thread without first posting a reply, and do not reply without resolving. Steps 2, 3, and 4 are all required.
+Do not resolve a thread without first posting a reply, and do not reply without resolving. Steps 2 and 3 are always required; step 4 is conditional on whether code was changed.
 
 ## Review Hygiene (explicit)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,9 @@ When reading and acting on review comments or inline threads on a pull request:
 1. **Fix the code** — implement the requested change and push the commit.
 2. **Reply to each thread** — for every inline review thread addressed, post a reply explaining what was changed and which commit contains the fix (e.g. "Fixed in `abc1234` — …").
 3. **Resolve each thread** — after replying, mark the thread as resolved so reviewers can see at a glance what is still open.
+4. **Request a new review** — once all threads are resolved, post a PR comment with `@Codex review` to trigger the next automated review cycle.
 
-Do not resolve a thread without first posting a reply, and do not reply without resolving. Both steps are required.
+Do not resolve a thread without first posting a reply, and do not reply without resolving. Steps 2, 3, and 4 are all required.
 
 ## Review Hygiene (explicit)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,16 @@ Any PR that adds a new exported function to `scripts/lib/` must include tests fo
 - Auto-fix only addresses issues explicitly named in the review feedback. It does not make speculative improvements.
 
 
+## PR Review Comment Workflow (interactive agents)
+
+When reading and acting on review comments or inline threads on a pull request:
+
+1. **Fix the code** — implement the requested change and push the commit.
+2. **Reply to each thread** — for every inline review thread addressed, post a reply explaining what was changed and which commit contains the fix (e.g. "Fixed in `abc1234` — …").
+3. **Resolve each thread** — after replying, mark the thread as resolved so reviewers can see at a glance what is still open.
+
+Do not resolve a thread without first posting a reply, and do not reply without resolving. Both steps are required.
+
 ## Review Hygiene (explicit)
 
 For any change to workflow behavior (for example files under `.github/workflows/` or automation scripts under `scripts/`):

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -202,7 +202,7 @@ The `CHECKPOINT_RUN_ID` environment variable overrides the default; each script 
 ### Cross-workflow artifact download
 
 - `validate-issue` passes its `GITHUB_RUN_ID` as the `validate_run_id` workflow-dispatch input when triggering `code-generation`. The generate job uses this run-id to download the artifact.
-- `auto-fix-pr` uses `gh run list` to find the latest successful `pr-review.yml` run for the PR branch and downloads its artifact by run-id.
+- `auto-fix-pr` queries the GitHub Actions artifacts API (`GET /repos/{owner}/{repo}/actions/artifacts?name=checkpoints-pr-{N}`) to find the most recent non-expired artifact by name, then downloads it via `curl`. This avoids a race condition where the triggering `pr-review.yml` run may not yet be listed as `completed` by `gh run list` at the moment the auto-fix job begins.
 
 ### Artifact retention
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -171,7 +171,7 @@ The following modules must maintain **≥ 80% test coverage** across statements,
 - **Checkpoint resume** (`scripts/lib/checkpoint.mjs`): every distinct failure branch (ENOENT vs non-ENOENT in `readCheckpoint`, `mkdir` propagation in `writeCheckpoint`) must have a dedicated test case.
 - **Configuration** (`scripts/lib/config.mjs`): provider detection, environment variable loading, and LLM config construction paths.
 - **LLM client** (`scripts/lib/llm_client.mjs`): provider routing, fallback on transient errors, and permanent-error short-circuit.
-- **Output writer** (`scripts/lib/output_writer.mjs`): JSON parsing fallbacks, validation error branches, and file write paths.
+- **Output writer** (`scripts/lib/output_writer.mjs`): JSON parsing (fence-first strategy, case-insensitive fence detection, `JsonParseError` typed errors with full tier diagnostics), validation error branches, and file write paths.
 
 ## Checkpoint Resume
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,7 @@ Requires Node.js 20+. All tests should pass in under a few seconds.
 
 | File | Tests | What is covered |
 |------|-------|-----------------|
-| `scripts/lib/output_writer.mjs` | 10 | Field validation, path safety (absolute paths, `..` traversal), 16 000-char size limit, type coercion |
+| `scripts/lib/output_writer.mjs` | 30 | JSON parsing (fence-first, case-insensitive fence detection, `JsonParseError` typed errors with full tier diagnostics), field validation, path safety (absolute paths, `..` traversal), 16 000-char size limit, type coercion |
 | `scripts/lib/config.mjs` | 12 | `requireEnv` missing/empty vars, `loadConfigFromEnv` defaults and required fields, `buildDeterministicPrompt` output structure, `loadLabelsConfig` group resolution |
 | `scripts/lib/groq_client.mjs` | 7 | HTTP errors, non-JSON response, malformed `choices`, Authorization header, temperature payload |
 | `scripts/lib/anthropic_client.mjs` | 10 | HTTP errors, non-JSON response, malformed `content`, `x-api-key` header, `anthropic-version` header, temperature, `max_tokens`, system prompt placement |

--- a/scripts/auto_fix_pr.mjs
+++ b/scripts/auto_fix_pr.mjs
@@ -49,8 +49,7 @@ function isManualRerunRequested(eventPayload) {
   return /-\s*\[x\]\s*(relancer\s+auto\s*fixer|rerun\s+auto\s*-?\s*fix(er)?)/i.test(body);
 }
 
-const WORKSPACE_ROOT = path.resolve(process.env.GITHUB_WORKSPACE || process.cwd());
-const CHECKPOINT_DIR = path.join(WORKSPACE_ROOT, '.github', 'checkpoints');
+const CHECKPOINT_DIR = path.resolve('./checkpoints');
 
 async function cleanupCheckpointFiles() {
   let entries;

--- a/scripts/lib/output_writer.mjs
+++ b/scripts/lib/output_writer.mjs
@@ -3,23 +3,38 @@ import path from 'node:path';
 
 const MAX_FILE_COUNT = 6;
 
+export class JsonParseError extends Error {
+  constructor(message, { raw, parseErrors }) {
+    super(message);
+    this.name = 'JsonParseError';
+    this.raw = raw;
+    this.parseErrors = parseErrors;
+  }
+}
+
 export function parseJsonResponse(raw) {
   const parseErrors = [];
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
-    parseErrors.push(`direct parse: ${err.message}`);
-  }
 
-  const fenced = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  // Tier 1: strip markdown code fence, then parse the interior
+  const fenced = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/i);
   if (fenced) {
     try {
       return JSON.parse(fenced[1].trim());
     } catch (err) {
       parseErrors.push(`fenced parse: ${err.message}`);
     }
+  } else {
+    parseErrors.push('fenced parse: no fence found');
   }
 
+  // Tier 2: direct parse (handles clean JSON with no wrapping)
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    parseErrors.push(`direct parse: ${err.message}`);
+  }
+
+  // Tier 3: brace-extraction slice (handles prose-wrapped JSON)
   const start = raw.indexOf('{');
   const end = raw.lastIndexOf('}');
   if (start !== -1 && end > start) {
@@ -28,9 +43,14 @@ export function parseJsonResponse(raw) {
     } catch (err) {
       parseErrors.push(`slice parse: ${err.message}`);
     }
+  } else {
+    parseErrors.push('slice parse: no brace pair found');
   }
 
-  throw new Error(`AI response was not valid JSON (${parseErrors.join('; ')})`);
+  throw new JsonParseError(
+    `AI response was not valid JSON (${parseErrors.join('; ')})`,
+    { raw, parseErrors },
+  );
 }
 const MAX_FILE_CONTENT_LENGTH = 16000;
 

--- a/scripts/lib/output_writer.mjs
+++ b/scripts/lib/output_writer.mjs
@@ -15,7 +15,16 @@ export class JsonParseError extends Error {
 export function parseJsonResponse(raw) {
   const parseErrors = [];
 
-  // Tier 1: strip markdown code fence, then parse the interior
+  // Tier 1: direct parse — wins for any clean JSON (including JSON whose
+  // string fields contain triple-backtick snippets that would confuse the
+  // fence regex below)
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    parseErrors.push(`direct parse: ${err.message}`);
+  }
+
+  // Tier 2: strip markdown code fence, then parse the interior
   const fenced = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/i);
   if (fenced) {
     try {
@@ -25,13 +34,6 @@ export function parseJsonResponse(raw) {
     }
   } else {
     parseErrors.push('fenced parse: no fence found');
-  }
-
-  // Tier 2: direct parse (handles clean JSON with no wrapping)
-  try {
-    return JSON.parse(raw);
-  } catch (err) {
-    parseErrors.push(`direct parse: ${err.message}`);
   }
 
   // Tier 3: brace-extraction slice (handles prose-wrapped JSON)

--- a/scripts/tests/auto_fix_pr.test.mjs
+++ b/scripts/tests/auto_fix_pr.test.mjs
@@ -546,7 +546,7 @@ test('auto_fix_pr resets attempt labels and checkpoint files when checkbox rerun
   const server = await startMockServer(makeHandler({ labelsBody: existingLabels }));
   const eventFile = await writeEventFile();
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'auto-fix-rerun-'));
-  const checkpointDir = path.join(tmpDir, '.github', 'checkpoints');
+  const checkpointDir = path.join(tmpDir, 'checkpoints');
   const outputFile = path.join(os.tmpdir(), `autofix-output-reset-${Date.now()}.txt`);
   try {
     await fs.mkdir(checkpointDir, { recursive: true });

--- a/scripts/tests/output_writer.test.mjs
+++ b/scripts/tests/output_writer.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { parseJsonResponse, validateAiOutput, writeGeneratedFiles } from '../lib/output_writer.mjs';
+import { parseJsonResponse, validateAiOutput, writeGeneratedFiles, JsonParseError } from '../lib/output_writer.mjs';
 
 // parseJsonResponse tests
 
@@ -29,6 +29,58 @@ test('parseJsonResponse extracts JSON when there is surrounding prose', () => {
 
 test('parseJsonResponse throws for completely non-JSON text', () => {
   assert.throws(() => parseJsonResponse('not json at all'), /not valid JSON/);
+});
+
+test('parseJsonResponse parses JSON wrapped in ```JSON (uppercase) fences', () => {
+  const result = parseJsonResponse('```JSON\n{"summary":"fix","changes":[]}\n```');
+  assert.deepEqual(result, { summary: 'fix', changes: [] });
+});
+
+test('parseJsonResponse parses JSON wrapped in ```Json (mixed-case) fences', () => {
+  const result = parseJsonResponse('```Json\n{"summary":"fix","changes":[]}\n```');
+  assert.deepEqual(result, { summary: 'fix', changes: [] });
+});
+
+test('parseJsonResponse throws JsonParseError (not generic Error) for invalid input', () => {
+  assert.throws(
+    () => parseJsonResponse('not json at all'),
+    (err) => err instanceof JsonParseError,
+  );
+});
+
+test('parseJsonResponse error includes all three strategy entries in parseErrors', () => {
+  let caught;
+  try {
+    parseJsonResponse('not json at all');
+  } catch (err) {
+    caught = err;
+  }
+  assert.ok(caught instanceof JsonParseError);
+  assert.ok(caught.parseErrors.some((e) => e.startsWith('fenced parse:')));
+  assert.ok(caught.parseErrors.some((e) => e.startsWith('direct parse:')));
+  assert.ok(caught.parseErrors.some((e) => e.startsWith('slice parse:')));
+});
+
+test('parseJsonResponse error attaches raw input to JsonParseError.raw', () => {
+  const input = 'totally not json';
+  let caught;
+  try {
+    parseJsonResponse(input);
+  } catch (err) {
+    caught = err;
+  }
+  assert.equal(caught.raw, input);
+});
+
+test('parseJsonResponse records fenced parse error first when fence contains invalid JSON', () => {
+  let caught;
+  try {
+    parseJsonResponse('```json\nnot valid json\n```');
+  } catch (err) {
+    caught = err;
+  }
+  assert.ok(caught instanceof JsonParseError);
+  assert.match(caught.parseErrors[0], /^fenced parse:/);
 });
 
 test('validateAiOutput returns trimmed fields for valid input', () => {

--- a/scripts/tests/output_writer.test.mjs
+++ b/scripts/tests/output_writer.test.mjs
@@ -72,7 +72,7 @@ test('parseJsonResponse error attaches raw input to JsonParseError.raw', () => {
   assert.equal(caught.raw, input);
 });
 
-test('parseJsonResponse records fenced parse error first when fence contains invalid JSON', () => {
+test('parseJsonResponse records direct parse error first, then fenced parse error', () => {
   let caught;
   try {
     parseJsonResponse('```json\nnot valid json\n```');
@@ -80,7 +80,8 @@ test('parseJsonResponse records fenced parse error first when fence contains inv
     caught = err;
   }
   assert.ok(caught instanceof JsonParseError);
-  assert.match(caught.parseErrors[0], /^fenced parse:/);
+  assert.match(caught.parseErrors[0], /^direct parse:/);
+  assert.match(caught.parseErrors[1], /^fenced parse:/);
 });
 
 test('validateAiOutput returns trimmed fields for valid input', () => {


### PR DESCRIPTION
Improves LLM response parsing robustness in parseJsonResponse():
- Reorders tiers to try markdown fence extraction first (most common LLM deviation)
- Adds /i flag to fence regex to handle ```JSON / ```Json (uppercase variants)
- Adds else-branches so all three tiers always record a result in parseErrors, eliminating silent gaps in diagnostic messages
- Exports JsonParseError class (extends Error) with .raw and .parseErrors fields for typed error handling by callers

Adds 6 new tests covering case-insensitive fences, instanceof checks, complete tier diagnostics, raw attachment, and fence-first ordering. Updates docs/testing.md test count and docs/code-generation.md coverage description.