### PR TITLE
docs(adr): add ADR-0014 through ADR-0016 for prompt caching, JSON parsing, and changelog gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ Entries are grouped by date. Add new entries under `[Unreleased]`.
 ### Added
 - Automated changelog gate: `scripts/check_changelog.mjs` verifies that any PR touching entrypoint scripts or ADR files adds an entry under `## [Unreleased]`; enforced by `.github/workflows/changelog-check.yml` on every PR
 - Context-aware PR review: `scripts/lib/change_classifier.mjs` classifies changed files before the LLM review and sets `tests_expected` so documentation-only, configuration-only, and lock-file-only PRs no longer receive irrelevant test-coverage findings (PR #148)
+- ADR-0014: Anthropic prompt caching on system prompts — documents the `cache_control: { type: 'ephemeral' }` decision in `anthropic_client.mjs` (PR #143)
+- ADR-0015: Three-tier JSON parsing with typed errors — documents `JsonParseError` class and Tier 1→2→3 cascade ordering invariant in `output_writer.mjs` (PR #144)
+- ADR-0016: Changelog CI gate for entrypoint scripts and ADR files — documents `check_changelog.mjs`, `changelog_checker.mjs`, and `changelog-check.yml` (PR #146)
 
 ## [2026-06-01]
 
 ### Added
 - Metrics storage as append-only JSONL (`metrics/runs.jsonl`) with same-run deduplication via `GITHUB_RUN_ID`+`GITHUB_RUN_ATTEMPT` composite key; `deduplicateMetrics` in `scripts/lib/metrics.mjs` filters duplicate records at report time (ADR-0013)
 - Anthropic prompt caching on system prompts — reduces token cost on repeated LLM calls with identical system content (PR #143)
+- Three-tier JSON parsing in `scripts/lib/output_writer.mjs`: `JsonParseError` typed error with `raw` and `parseErrors[]` fields; direct parse (Tier 1) → fence-strip (Tier 2) → brace-extraction (Tier 3) cascade (PR #144)
 
 ## [2026-05-25]
 

--- a/docs/adr/0014-anthropic-prompt-caching.md
+++ b/docs/adr/0014-anthropic-prompt-caching.md
@@ -1,0 +1,72 @@
+# ADR-0014: Anthropic prompt caching on system prompts
+
+- **Date:** 2026-05-31
+- **Status:** Accepted
+
+## Context
+
+Each call to the Anthropic Messages API sends the full system prompt in the request
+body. For the automation pipeline, system prompts are large (hundreds to thousands of
+tokens) and identical across all calls in a single batch: the same
+`generation-system.md`, `auto-fix-system.md`, or `pr-review-system.md` content is
+sent on every retry and on every re-invocation of the same stage. Anthropic's API
+supports prompt caching, which stores the prefix of a request on Anthropic's
+infrastructure for the duration of the cache TTL, avoiding re-processing on subsequent
+calls with the same prefix.
+
+Groq, the other supported provider, does not offer an equivalent prompt-caching
+mechanism. Any caching behaviour must therefore be provider-specific.
+
+Token thresholds for cache eligibility differ by model family:
+- Haiku and Sonnet models: ≥2048 tokens in the cached block.
+- Opus models: ≥4096 tokens in the cached block.
+
+System prompts shorter than these thresholds are never cached by Anthropic, even if
+`cache_control` is present. This is a silent no-op: the API accepts the field without
+error and simply does not cache.
+
+## Decision
+
+In `scripts/lib/anthropic_client.mjs`, send the system prompt as a structured content
+block with `cache_control: { type: 'ephemeral' }` instead of a plain string:
+
+```js
+system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
+```
+
+`type: 'ephemeral'` requests a cache TTL that covers the lifetime of a request batch
+(as defined by Anthropic's API). The change is a one-line diff in `callAnthropic()`;
+no caller changes are required because the `systemPrompt` parameter remains a plain
+string at the call site — the structured wrapping is an implementation detail of the
+Anthropic client.
+
+This change applies only to the Anthropic provider. `scripts/lib/groq_client.mjs` is
+unchanged.
+
+## Alternatives Considered
+
+**Cache the user prompt instead of (or in addition to) the system prompt** — user
+prompts are dynamic (they include the issue body, PR diff, or review feedback), so they
+differ on every call. Caching them would yield negligible hit rates. Rejected.
+
+**Implement caching in `llm_client.mjs` (the provider router)** — would require the
+router to know about Anthropic's structured content format, creating provider-specific
+coupling in a provider-agnostic module. Rejected in favour of keeping the detail inside
+`anthropic_client.mjs`.
+
+**Opt-in caching via a caller flag** — adds API surface area for a capability that is
+always beneficial when the system prompt exceeds the token threshold. Rejected as
+unnecessary complexity.
+
+## Consequences
+
+- ✅ Repeated LLM calls within the same pipeline run (retries, multi-step auto-fix
+  loops) pay reduced input-token cost when the system prompt meets the cache threshold.
+- ✅ Change is confined to `anthropic_client.mjs`; no caller or router changes needed.
+- ✅ Groq calls are unaffected; the providers remain independently isolated.
+- ⚠️ Caching is silently skipped for prompts below the token threshold (≥2048 for
+  Haiku/Sonnet, ≥4096 for Opus). Operators cannot observe whether a given call was
+  actually served from cache without inspecting the `usage` field in the API response.
+- ⚠️ This creates a behavioural asymmetry between the Anthropic and Groq providers:
+  Anthropic calls benefit from cache savings on repeated system prompts; Groq calls do
+  not. Cost comparisons between providers must account for this difference.

--- a/docs/adr/0014-anthropic-prompt-caching.md
+++ b/docs/adr/0014-anthropic-prompt-caching.md
@@ -18,8 +18,8 @@ Groq, the other supported provider, does not offer an equivalent prompt-caching
 mechanism. Any caching behaviour must therefore be provider-specific.
 
 Token thresholds for cache eligibility differ by model family:
-- Haiku and Sonnet models: ≥2048 tokens in the cached block.
-- Opus models: ≥4096 tokens in the cached block.
+- Opus and Sonnet models: ≥1024 tokens in the cached block.
+- Haiku models: ≥2048 tokens in the cached block.
 
 System prompts shorter than these thresholds are never cached by Anthropic, even if
 `cache_control` is present. This is a silent no-op: the API accepts the field without
@@ -64,8 +64,8 @@ unnecessary complexity.
   loops) pay reduced input-token cost when the system prompt meets the cache threshold.
 - ✅ Change is confined to `anthropic_client.mjs`; no caller or router changes needed.
 - ✅ Groq calls are unaffected; the providers remain independently isolated.
-- ⚠️ Caching is silently skipped for prompts below the token threshold (≥2048 for
-  Haiku/Sonnet, ≥4096 for Opus). Operators cannot observe whether a given call was
+- ⚠️ Caching is silently skipped for prompts below the token threshold (≥1024 for
+  Opus/Sonnet, ≥2048 for Haiku). Operators cannot observe whether a given call was
   actually served from cache without inspecting the `usage` field in the API response.
 - ⚠️ This creates a behavioural asymmetry between the Anthropic and Groq providers:
   Anthropic calls benefit from cache savings on repeated system prompts; Groq calls do

--- a/docs/adr/0015-three-tier-json-parsing.md
+++ b/docs/adr/0015-three-tier-json-parsing.md
@@ -42,7 +42,7 @@ class in `scripts/lib/output_writer.mjs`.
 |------|----------|-----------|
 | 1 | `JSON.parse(raw)` directly | Must be first: valid JSON strings may contain `` ``` `` sequences that the Tier 2 regex would incorrectly match as a fence |
 | 2 | Strip markdown fence (`` ```[json]…``` ``), then `JSON.parse` interior | Handles the common model behaviour of wrapping output in a code block |
-| 3 | Slice from first `{` to last `}`, then `JSON.parse` | Handles prose-prefixed JSON; only entered if Tier 2 finds no fence |
+| 3 | Slice from first `{` to last `}`, then `JSON.parse` | Handles prose-prefixed JSON; entered whenever Tier 2 did not return — either no fence was found, or a fence was found but its content was not valid JSON |
 
 Each tier records its failure reason (or "no fence found" / "no brace pair found") into
 `parseErrors[]` unconditionally. If all three fail, a `JsonParseError` is thrown with

--- a/docs/adr/0015-three-tier-json-parsing.md
+++ b/docs/adr/0015-three-tier-json-parsing.md
@@ -1,0 +1,84 @@
+# ADR-0015: Three-tier JSON parsing with typed errors
+
+- **Date:** 2026-06-01
+- **Status:** Accepted
+
+## Context
+
+LLM responses intended to be JSON are not always clean JSON. Models occasionally wrap
+their output in a markdown code fence (` ```json … ``` `), prepend explanatory prose,
+or emit both a preamble and a well-formed JSON object. A single `JSON.parse()` fails
+on cases 2 and 3.
+
+The existing `parseJsonResponse()` in `scripts/lib/output_writer.mjs` already attempted
+direct parse, fence-strip, and brace-extraction, but had three gaps:
+
+1. **Ordering risk** — if the fence regex ran before `JSON.parse()`, valid JSON whose
+   string fields contained triple-backtick snippets (e.g. a code-review payload quoting
+   a fenced code block from the PR diff) could be mis-parsed. The ordering guarantee was
+   implicit rather than documented and enforced.
+
+2. **Silent failure mode** — when all three strategies failed, the thrown `Error` had
+   only a concatenated string message. Callers needing to log the raw response for
+   diagnosis or classify which tier failed had to re-parse the message string.
+
+3. **Missing diagnostic accumulation** — the fence tier silently skipped its error
+   accumulation when no fence was found, and the slice tier did the same when no brace
+   pair was found, producing incomplete diagnostic strings.
+
+## Decision
+
+Formalise the three-tier cascade in `parseJsonResponse()` and introduce a typed error
+class in `scripts/lib/output_writer.mjs`.
+
+**`JsonParseError`** extends `Error` with two structured fields:
+- `raw` — the original LLM response string, for logging and debugging.
+- `parseErrors[]` — one diagnostic string per tier, in order, so callers know exactly
+  which tier failed and why.
+
+**Tier ordering (invariant: Tier 1 always runs first):**
+
+| Tier | Strategy | Rationale |
+|------|----------|-----------|
+| 1 | `JSON.parse(raw)` directly | Must be first: valid JSON strings may contain `` ``` `` sequences that the Tier 2 regex would incorrectly match as a fence |
+| 2 | Strip markdown fence (`` ```[json]…``` ``), then `JSON.parse` interior | Handles the common model behaviour of wrapping output in a code block |
+| 3 | Slice from first `{` to last `}`, then `JSON.parse` | Handles prose-prefixed JSON; only entered if Tier 2 finds no fence |
+
+Each tier records its failure reason (or "no fence found" / "no brace pair found") into
+`parseErrors[]` unconditionally. If all three fail, a `JsonParseError` is thrown with
+all three diagnostics populated.
+
+The fence regex uses the `i` flag to match `` ```JSON `` (uppercase) in addition to
+`` ```json ``.
+
+## Alternatives Considered
+
+**Fence-first ordering** — apply the fence regex before `JSON.parse()`. Rejected
+because valid JSON containing triple-backtick sequences in string values (e.g. a
+code-review payload quoting a fenced code block from the PR diff) would be silently
+mis-parsed. Tier 1 must protect this case.
+
+**LLM-side enforcement via `response_format: { type: "json_object" }`** — Groq's API
+supports this mode; Anthropic's does not. Applying it only to Groq would create
+divergent parsing logic per provider. Keeping a unified three-tier parser across
+providers is simpler.
+
+**Throw a plain `Error` with a structured `cause`** — keeps the class hierarchy simple
+but requires callers to downcast or inspect `cause` for diagnostics, which is less
+ergonomic than named fields on a dedicated class.
+
+## Consequences
+
+- ✅ Callers can `instanceof JsonParseError` to distinguish JSON-format failures from
+  other errors (network, auth) without string matching.
+- ✅ `raw` and `parseErrors[]` are always populated on failure, giving operators the
+  full context needed to diagnose why a specific LLM response was rejected.
+- ✅ The Tier 1 → Tier 2 → Tier 3 ordering is documented and enforced by code comment,
+  preventing future refactors from silently breaking the invariant.
+- ⚠️ The three-tier cascade adds two additional parse attempts on every failure path.
+  This is negligible in practice (JSON.parse is fast; LLM call latency dominates) but
+  not zero cost.
+- ⚠️ Tier 3 (brace extraction) is a heuristic: it returns the substring between the
+  first `{` and the last `}`, which is incorrect for responses embedding multiple
+  top-level JSON objects or `{` in prose before the actual object. Such cases produce a
+  Tier 3 parse error rather than a wrong parse, which is the safer failure mode.

--- a/docs/adr/0016-changelog-ci-gate.md
+++ b/docs/adr/0016-changelog-ci-gate.md
@@ -1,0 +1,95 @@
+# ADR-0016: Changelog CI gate for entrypoint scripts and ADR files
+
+- **Date:** 2026-06-01
+- **Status:** Accepted
+
+## Context
+
+As the project's automated loop shipped new features (prompt caching, JSON parsing
+improvements, metrics), `CHANGELOG.md` fell behind. Post-hoc ADR syncs were required
+(see commit `0aab9d3`) to document decisions that had already been merged. The root
+cause was that there was no machine-enforced rule requiring authors to update the
+changelog when merging automation changes.
+
+The two categories of change most likely to go undocumented are:
+1. **Entrypoint scripts** — `scripts/*.mjs` (top-level only; `scripts/lib/` contains
+   library modules documented via the entrypoints that call them).
+2. **ADR files** — `docs/adr/NNNN-*.md` (architecture decisions should be reflected
+   in the changelog when they are added or updated).
+
+A manually enforced policy in `CONTRIBUTING.md` existed but was not reliably followed.
+
+## Decision
+
+Introduce a CI gate that fails any PR touching trigger files unless `CHANGELOG.md`
+contains at least one added bullet (`- ` or `* ` prefix) under `## [Unreleased]`.
+
+**Three components:**
+
+**`scripts/lib/changelog_checker.mjs`** — pure library module, extracted for unit
+testability. Exports:
+- `ENTRYPOINT_RE` — `/^scripts\/[^/]+\.mjs$/` — matches `scripts/*.mjs` but not
+  `scripts/lib/*.mjs` or `scripts/tests/*.mjs`.
+- `ADR_RE` — `/^docs\/adr\/\d{4}-[^/]+\.md$/` — matches `docs/adr/NNNN-title.md`.
+- `findTriggerFiles(changedFiles)` — filters the changed-file list to those matching
+  either regex.
+- `hasUnreleasedEntry(diff, changelogContent)` — walks the diff hunk-by-hunk, tracking
+  new-file line numbers. Returns `true` if any added line (`+` prefix) falls within the
+  `## [Unreleased]` section and matches `/^[-*] /` (bullet prefix). Uses
+  `changelogContent` (the post-change file) to locate section boundaries, so the check
+  works even when the `## [Unreleased]` heading itself is not in the diff hunk.
+
+**`scripts/check_changelog.mjs`** — entrypoint invoked by CI. Computes changed files
+via `git diff --name-only origin/${BASE_REF}...HEAD`, calls `findTriggerFiles`, skips
+with exit 0 if no trigger files changed, and calls `hasUnreleasedEntry` on the
+CHANGELOG.md diff plus the current file content. Fails with a descriptive error message
+and exit 1 if the check fails.
+
+**`.github/workflows/changelog-check.yml`** — `pull_request` trigger (all PRs),
+`fetch-depth: 0` required so `git diff origin/<base>...HEAD` can traverse history,
+runs `node scripts/check_changelog.mjs` with `BASE_REF: ${{ github.base_ref }}`.
+
+**Trigger scope:** `scripts/*.mjs` (top-level entrypoints) OR `docs/adr/NNNN-*.md`.
+`scripts/lib/` and `scripts/tests/` are intentionally excluded: library and test
+changes are captured through the entrypoints that surface them.
+
+**Gate is skipped** (exit 0) when no trigger files are in the diff. PRs that touch
+only `scripts/lib/`, tests, workflows, prompts, or documentation outside the ADR
+directory do not require a changelog entry.
+
+## Alternatives Considered
+
+**Enforce via pre-commit hook** — runs locally on the author's machine rather than in
+CI. Hooks can be bypassed with `--no-verify` and are not installed automatically for
+new contributors. Rejected in favour of a CI gate that cannot be skipped.
+
+**Require changelog updates for all changed files** — would mandate entries for
+workflow YAML tweaks, test additions, and prompt updates that have no user-visible
+behaviour change. Creates noise and reduces changelog signal-to-noise ratio. Rejected
+in favour of the narrower trigger scope.
+
+**Pattern-match the entire `scripts/` tree (including `lib/` and `tests/`)** — would
+force changelog entries for internal refactors and test additions that do not change
+observable pipeline behaviour. Rejected; `scripts/*.mjs` entrypoints are the correct
+boundary because they represent the externally-visible surface of the automation.
+
+**Require changelog entries per-commit via commit-message linting** — adds toolchain
+complexity (commitlint or similar) and enforces at commit time rather than PR time,
+blocking contributors on every intermediate commit. Rejected for MVP scope.
+
+## Consequences
+
+- ✅ Any PR that ships or documents a feature (entrypoint change or new ADR) is blocked
+  until the changelog is updated — no more post-hoc sync commits.
+- ✅ The gate is skipped for non-trigger files, keeping it low-friction for internal
+  changes (test fixes, workflow tuning, prompt edits).
+- ✅ `changelog_checker.mjs` is a pure module with no I/O; it is fully unit-tested
+  without mocking.
+- ✅ `fetch-depth: 0` in checkout enables accurate `git diff origin/<base>...HEAD`
+  computation in all PR scenarios, including forks.
+- ⚠️ ADR-only PRs (like the one adding this ADR) must themselves include a
+  CHANGELOG.md entry — a self-referential requirement that is intentional: ADR
+  additions are notable enough to log.
+- ⚠️ `scripts/lib/` changes are not gated. A library module that materially changes
+  behaviour without touching an entrypoint script will slip through without a changelog
+  entry. This is the accepted trade-off for keeping the trigger scope narrow.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,3 +17,6 @@ Architecture Decision Records (ADR) for the MVP Issue → AI → PR automation.
 - [ADR-0011: Checkpoint-resume for state persistence across Actions jobs](./0011-checkpoint-resume-state-persistence.md)
 - [ADR-0012: Coverage enforcement delegated to CI](./0012-coverage-enforcement-delegation-to-ci.md)
 - [ADR-0013: Metrics storage as append-only JSONL and same-run deduplication via GITHUB_RUN_ID](./0013-metrics-append-only-jsonl-and-deduplication.md)
+- [ADR-0014: Anthropic prompt caching on system prompts](./0014-anthropic-prompt-caching.md)
+- [ADR-0015: Three-tier JSON parsing with typed errors](./0015-three-tier-json-parsing.md)
+- [ADR-0016: Changelog CI gate for entrypoint scripts and ADR files](./0016-changelog-ci-gate.md)


### PR DESCRIPTION
Documents three features shipped without ADRs after commit 0aab9d3:
- ADR-0014: Anthropic ephemeral prompt caching in anthropic_client.mjs (PR #143)
- ADR-0015: Three-tier JSON parsing and JsonParseError in output_writer.mjs (PR #144)
- ADR-0016: Changelog CI gate (check_changelog.mjs + changelog_checker.mjs + workflow) (PR #146)

Updates docs/adr/README.md index and retroactively adds the missing CHANGELOG.md
entry for fence-first JSON parsing under [2026-06-01].

https://claude.ai/code/session_01RT3QthMDxpoXmRG6p63XJy