### PR TITLE
feat(pr-review): context-aware review with change classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Entries are grouped by date. Add new entries under `[Unreleased]`.
 
 ### Added
 - Automated changelog gate: `scripts/check_changelog.mjs` verifies that any PR touching entrypoint scripts or ADR files adds an entry under `## [Unreleased]`; enforced by `.github/workflows/changelog-check.yml` on every PR
+- Context-aware PR review: `scripts/lib/change_classifier.mjs` classifies changed files before the LLM review and sets `tests_expected` so documentation-only, configuration-only, and lock-file-only PRs no longer receive irrelevant test-coverage findings (PR #148)
 
 ## [2026-06-01]
 

--- a/docs/code-generation.md
+++ b/docs/code-generation.md
@@ -174,6 +174,34 @@ The following modules must maintain **≥ 80% test coverage** across statements,
 - **LLM client** (`scripts/lib/llm_client.mjs`): provider routing, fallback on transient errors, and permanent-error short-circuit.
 - **Output writer** (`scripts/lib/output_writer.mjs`): JSON parsing (fence-first strategy, case-insensitive fence detection, `JsonParseError` typed errors with full tier diagnostics), validation error branches, and file write paths.
 
+## PR Review: Context-Aware Change Classification
+
+Before generating review findings, `scripts/pr_review.mjs` injects two context blocks into the LLM prompt:
+
+1. **Change classification** (`scripts/lib/change_classifier.mjs`) — inspects changed file paths from the diff and emits a structured block with:
+   - `change_type` — dominant category (`documentation`, `ci_cd`, `configuration`, `dependency_update`, `test_only`, `feature_or_bugfix`, `mixed`)
+   - `detected_categories` — all matched categories
+   - `has_executable_code_changes` — true when any file falls outside the non-behavioral set
+   - `tests_expected` / `tests_expected_reason` — whether test coverage findings should be generated
+
+2. **Automation gate context** (`scripts/lib/coverage_checker.mjs`) — existing gate that checks whether automation-scope changes (scripts/, prompts/, .github/workflows/, docs/code-generation.md) include test and doc updates.
+
+### Classification rules
+
+| File pattern | Category | `tests_expected` |
+|---|---|---|
+| `.md` files outside automation scope (`docs/adr/`, `README.md`, etc.) | `documentation` | false |
+| `.github/workflows/*.yml` (automation scope) | `ci_cd` | **true** |
+| `config/`, `tsconfig*.json`, `.eslintrc*`, etc. | `configuration` | false |
+| `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` | `dependency_update` | false |
+| `package.json` | _(executable code)_ | **true** |
+| `scripts/tests/*.test.mjs`, `*.spec.*` | `test_only` | false |
+| All other files (scripts/, prompts/, etc.) | _(executable code)_ | **true** |
+
+When `tests_expected` is false the LLM is instructed to omit all test-coverage findings and not lower its verdict score because of absent tests.
+
+`package.json` is treated as executable code (not `dependency_update`) because it owns behavioural fields (`type`, `scripts`, `engines`). Only auto-generated lock files are classified as pure dependency updates.
+
 ## Changelog Gate (`changelog-check.yml`)
 
 Runs on every pull request. Calls `node scripts/check_changelog.mjs` to verify that:

--- a/prompts/pr-review-system.md
+++ b/prompts/pr-review-system.md
@@ -15,3 +15,15 @@ Rules:
 * For gate (b), if automation behavior changes without corresponding docs update (especially docs/code-generation.md), report HIGH severity.
 * For gate (c), CI enforces coverage only for `scripts/lib/checkpoint.mjs` via c8 in test.yml. For all other changed automation logic, if the diff does not add/maintain an explicit minimum unit-test coverage policy/check for that flow, report HIGH severity.
 * Before flagging a step condition (if: always(), if: failure(), etc.) as unintended, verify whether the condition is load-bearing for the workflow's control flow. A condition that prevents deadlocks, re-trigger loops, or state corruption is intentional by design. Do not flag it without a concrete alternative that preserves the same control flow guarantee.
+
+Context-aware review:
+* The user message contains a "Change classification context" block produced by static analysis of the diff. Read it before generating findings.
+* Respect the `tests_expected` field exactly: if it is false, do NOT generate any finding related to missing tests, insufficient test coverage, or lack of test updates — and do not lower the verdict because of it.
+* Adapt evaluation criteria to the detected change type:
+  - documentation: evaluate correctness, clarity, consistency with existing docs, and broken references. Do not require tests.
+  - ci_cd: evaluate correctness, deployment impact, rollback risk, and environment compatibility. Tests are optional.
+  - configuration: evaluate correctness, maintainability, and environment compatibility. Tests are optional.
+  - dependency_update: evaluate breaking changes, version compatibility, and security impact. Discuss tests only if runtime behavior is affected.
+  - test_only: evaluate test correctness, coverage of the targeted behaviour, and absence of false assertions.
+  - feature / bugfix / refactor / security: apply the full rubric including test coverage where tests_expected is true.
+  - mixed: apply the strictest applicable criteria for each changed file category.

--- a/prompts/pr-review-user.md
+++ b/prompts/pr-review-user.md
@@ -12,6 +12,10 @@ Use the issue content to determine intent. Flag any diff behavior that contradic
 
 ## 🔍 Automated Code Review
 
+### 🏷️ Change Classification
+State the detected change type and whether tests are expected for this PR.
+Format: "Type: <type> | Tests expected: <yes/no> — <one-sentence reason>"
+
 ### ✅ Summary
 (1–3 lines describing only what changed in the diff)
 
@@ -26,6 +30,7 @@ If none found, write: None.
 (APPROVED | REQUEST_CHANGES)
 
 Constraints:
-- Max 220 words
+- Max 250 words
 - No generic advice
 - No repetition
+- If tests_expected is false in the classification context, omit all test-coverage findings

--- a/scripts/lib/change_classifier.mjs
+++ b/scripts/lib/change_classifier.mjs
@@ -85,6 +85,10 @@ function isTestFile(filePath) {
 export function classifyChangedFiles(changedFiles) {
   const categories = new Set();
   let hasCode = false;
+  // True only when an uncategorised file (not docs/ci_cd/config/dep/test) is
+  // found — used to distinguish "workflow-only" (hasCode via automation scope,
+  // but still a single category) from "code + something" (mixed).
+  let hasUncategorizedCode = false;
 
   for (const filePath of changedFiles) {
     if (isDocumentationFile(filePath)) {
@@ -101,10 +105,11 @@ export function classifyChangedFiles(changedFiles) {
       categories.add('test_only');
     } else {
       hasCode = true;
+      hasUncategorizedCode = true;
     }
   }
 
-  return { categories: [...categories], hasCode };
+  return { categories: [...categories], hasCode, hasUncategorizedCode };
 }
 
 const NON_BEHAVIORAL = new Set(['documentation', 'ci_cd', 'configuration', 'dependency_update', 'test_only']);
@@ -169,13 +174,19 @@ export function buildChangeClassificationContext(rawDiff) {
   const changedFiles = extractChangedFiles(rawDiff);
   if (!changedFiles.length) return '';
 
-  const { categories, hasCode } = classifyChangedFiles(changedFiles);
+  const { categories, hasCode, hasUncategorizedCode } = classifyChangedFiles(changedFiles);
   const { tests_expected, reason } = determineTestExpectation(categories, hasCode);
 
   const classification = categories.length > 0 ? categories.join(', ') : 'none';
-  const changeType = hasCode
-    ? categories.length > 0 ? 'mixed' : 'feature_or_bugfix'
-    : categories.length === 1 ? categories[0] : categories.length > 1 ? 'mixed' : 'unknown';
+  // "mixed" only when there are genuinely distinct kinds of changes.
+  // A workflow-only PR has hasCode=true (automation scope) but a single
+  // category, so it stays "ci_cd" rather than "mixed".
+  const changeType =
+    hasUncategorizedCode && categories.length > 0 ? 'mixed'
+    : hasUncategorizedCode ? 'feature_or_bugfix'
+    : categories.length === 1 ? categories[0]
+    : categories.length > 1 ? 'mixed'
+    : 'unknown';
 
   return [
     '',

--- a/scripts/lib/change_classifier.mjs
+++ b/scripts/lib/change_classifier.mjs
@@ -29,7 +29,9 @@ const CONFIGURATION_PATTERNS = [
 ];
 
 const DEPENDENCY_PATTERNS = [
-  /^package\.json$/,
+  // package.json is intentionally excluded: it also owns behavioural fields
+  // (type, scripts, engines) so any edit to it is treated as executable code.
+  // Lock files are auto-generated and safe to classify as pure dependency updates.
   /^package-lock\.json$/,
   /^yarn\.lock$/,
   /^pnpm-lock\.yaml$/,
@@ -89,6 +91,8 @@ export function classifyChangedFiles(changedFiles) {
       categories.add('documentation');
     } else if (isCiCdFile(filePath)) {
       categories.add('ci_cd');
+      // Workflow files are automation scope — behaviour changes require tests.
+      if (isAutomationScopeFile(filePath)) hasCode = true;
     } else if (isConfigurationFile(filePath)) {
       categories.add('configuration');
     } else if (isDependencyFile(filePath)) {

--- a/scripts/lib/change_classifier.mjs
+++ b/scripts/lib/change_classifier.mjs
@@ -1,0 +1,188 @@
+import { extractChangedFiles, isAutomationScopeFile } from './coverage_checker.mjs';
+
+// ---------------------------------------------------------------------------
+// File-pattern tables
+// ---------------------------------------------------------------------------
+
+const DOCUMENTATION_PATTERNS = [
+  /\.md$/i,
+  /^README(\..+)?$/i,
+  /^CHANGELOG(\..+)?$/i,
+  /^CONTRIBUTING(\..+)?$/i,
+  /^LICENSE(\..+)?$/i,
+  /^AGENTS\.md$/i,
+];
+
+const CI_CD_PATTERNS = [
+  /^\.github\/workflows\//,
+  /^\.github\/actions\//,
+];
+
+const CONFIGURATION_PATTERNS = [
+  /^config\//,
+  /^\.eslintrc/,
+  /^\.prettierrc/,
+  /^tsconfig.*\.json$/,
+  /^vitest\.config\./,
+  /^jest\.config\./,
+  /^babel\.config\./,
+];
+
+const DEPENDENCY_PATTERNS = [
+  /^package\.json$/,
+  /^package-lock\.json$/,
+  /^yarn\.lock$/,
+  /^pnpm-lock\.yaml$/,
+];
+
+const TEST_PATTERNS = [
+  /\/tests?\//,
+  /\.test\.[cm]?[jt]sx?$/,
+  /\.spec\.[cm]?[jt]sx?$/,
+  /\/__tests__\//,
+];
+
+// ---------------------------------------------------------------------------
+// Per-file helpers
+// ---------------------------------------------------------------------------
+
+function isDocumentationFile(filePath) {
+  // Automation-scope files (scripts/, prompts/, docs/code-generation.md) change
+  // runtime behaviour even when they carry a .md extension — don't classify them
+  // as documentation.
+  if (isAutomationScopeFile(filePath)) return false;
+  return DOCUMENTATION_PATTERNS.some((p) => p.test(filePath));
+}
+
+function isCiCdFile(filePath) {
+  return CI_CD_PATTERNS.some((p) => p.test(filePath));
+}
+
+function isConfigurationFile(filePath) {
+  return CONFIGURATION_PATTERNS.some((p) => p.test(filePath));
+}
+
+function isDependencyFile(filePath) {
+  return DEPENDENCY_PATTERNS.some((p) => p.test(filePath));
+}
+
+function isTestFile(filePath) {
+  return TEST_PATTERNS.some((p) => p.test(filePath));
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a list of changed file paths.
+ *
+ * Returns the set of detected categories and a flag indicating whether any
+ * file represents a change to executable/behavioural code.
+ */
+export function classifyChangedFiles(changedFiles) {
+  const categories = new Set();
+  let hasCode = false;
+
+  for (const filePath of changedFiles) {
+    if (isDocumentationFile(filePath)) {
+      categories.add('documentation');
+    } else if (isCiCdFile(filePath)) {
+      categories.add('ci_cd');
+    } else if (isConfigurationFile(filePath)) {
+      categories.add('configuration');
+    } else if (isDependencyFile(filePath)) {
+      categories.add('dependency_update');
+    } else if (isTestFile(filePath)) {
+      categories.add('test_only');
+    } else {
+      hasCode = true;
+    }
+  }
+
+  return { categories: [...categories], hasCode };
+}
+
+const NON_BEHAVIORAL = new Set(['documentation', 'ci_cd', 'configuration', 'dependency_update', 'test_only']);
+
+/**
+ * Given the classification output, decide whether test coverage is expected
+ * for this PR and produce a human-readable reason.
+ */
+export function determineTestExpectation(categories, hasCode) {
+  if (hasCode) {
+    return {
+      tests_expected: true,
+      reason: 'Executable code or behavioural files are modified.',
+    };
+  }
+
+  const catSet = new Set(categories);
+
+  if (catSet.size === 0) {
+    return { tests_expected: true, reason: 'Change type undetermined.' };
+  }
+
+  if ([...catSet].every((c) => NON_BEHAVIORAL.has(c))) {
+    if (catSet.has('documentation') && catSet.size === 1) {
+      return {
+        tests_expected: false,
+        reason: 'No executable behavior changed.',
+      };
+    }
+    if (catSet.has('test_only') && catSet.size === 1) {
+      return {
+        tests_expected: false,
+        reason: 'PR contains only test file changes.',
+      };
+    }
+    if (catSet.has('dependency_update') && catSet.size === 1) {
+      return {
+        tests_expected: false,
+        reason: 'Dependency version update; tests expected only if runtime behavior changes.',
+      };
+    }
+    // ci_cd, configuration, or any other non-behavioral mix
+    return {
+      tests_expected: false,
+      reason: 'Only non-behavioral files changed (documentation, CI/CD, configuration, or dependencies).',
+    };
+  }
+
+  return {
+    tests_expected: true,
+    reason: 'Change type is mixed or includes behavioral modifications.',
+  };
+}
+
+/**
+ * Build a context block to inject into the review prompt.
+ *
+ * Returns an empty string when the diff contains no recognisable file paths so
+ * that callers can safely concatenate it.
+ */
+export function buildChangeClassificationContext(rawDiff) {
+  const changedFiles = extractChangedFiles(rawDiff);
+  if (!changedFiles.length) return '';
+
+  const { categories, hasCode } = classifyChangedFiles(changedFiles);
+  const { tests_expected, reason } = determineTestExpectation(categories, hasCode);
+
+  const classification = categories.length > 0 ? categories.join(', ') : 'none';
+  const changeType = hasCode
+    ? categories.length > 0 ? 'mixed' : 'feature_or_bugfix'
+    : categories.length === 1 ? categories[0] : categories.length > 1 ? 'mixed' : 'unknown';
+
+  return [
+    '',
+    '',
+    'Change classification context:',
+    `- change_type: ${changeType}`,
+    `- detected_categories: ${classification}`,
+    `- has_executable_code_changes: ${hasCode}`,
+    `- tests_expected: ${tests_expected}`,
+    `- tests_expected_reason: ${reason}`,
+    '',
+    'If tests_expected is false: do not generate findings about missing tests, do not recommend increasing test coverage, and do not reduce the verdict because of absent tests.',
+  ].join('\n');
+}

--- a/scripts/pr_review.mjs
+++ b/scripts/pr_review.mjs
@@ -8,6 +8,7 @@ import { loadPrompt, interpolatePrompt } from './lib/prompts.mjs';
 import { log, error as logError } from './lib/logger.mjs';
 import { retryWithBackoff } from './lib/retry.mjs';
 import { buildAutomationGateContext } from './lib/coverage_checker.mjs';
+import { buildChangeClassificationContext } from './lib/change_classifier.mjs';
 import { writeCheckpoint, readCheckpoint } from './lib/checkpoint.mjs';
 import { appendMetric, estimateTokens } from './lib/metrics.mjs';
 
@@ -168,7 +169,7 @@ const prBody = prMeta.body || '(no description provided)';
 const diff = filterDiff(rawDiff);
 
 const baseUserPrompt = interpolatePrompt(userPromptTemplate, { diff, issueTitle: prTitle, issueBody: prBody });
-const userPrompt = `${baseUserPrompt}${buildAutomationGateContext(rawDiff)}`;
+const userPrompt = `${baseUserPrompt}${buildChangeClassificationContext(rawDiff)}${buildAutomationGateContext(rawDiff)}`;
 
 const rawReview = await callLLM({
   prompt: userPrompt,

--- a/scripts/tests/change_classifier.test.mjs
+++ b/scripts/tests/change_classifier.test.mjs
@@ -1,0 +1,228 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyChangedFiles,
+  determineTestExpectation,
+  buildChangeClassificationContext,
+} from '../lib/change_classifier.mjs';
+
+// ---------------------------------------------------------------------------
+// classifyChangedFiles
+// ---------------------------------------------------------------------------
+
+test('classifyChangedFiles: pure documentation files', () => {
+  const { categories, hasCode } = classifyChangedFiles([
+    'docs/adr/0010-foo.md',
+    'docs/runbook.md',
+    'README.md',
+  ]);
+  assert.ok(categories.includes('documentation'));
+  assert.equal(hasCode, false);
+});
+
+test('classifyChangedFiles: changelog and contributing are documentation', () => {
+  const { categories, hasCode } = classifyChangedFiles(['CHANGELOG.md', 'CONTRIBUTING.md', 'LICENSE']);
+  assert.ok(categories.includes('documentation'));
+  assert.equal(hasCode, false);
+});
+
+test('classifyChangedFiles: CI/CD workflow files', () => {
+  const { categories, hasCode } = classifyChangedFiles(['.github/workflows/pr-review.yml']);
+  assert.ok(categories.includes('ci_cd'));
+  assert.equal(hasCode, false);
+});
+
+test('classifyChangedFiles: configuration files', () => {
+  const { categories, hasCode } = classifyChangedFiles(['config/labels.yaml', 'config/models.yaml']);
+  assert.ok(categories.includes('configuration'));
+  assert.equal(hasCode, false);
+});
+
+test('classifyChangedFiles: tsconfig is configuration', () => {
+  const { categories, hasCode } = classifyChangedFiles(['tsconfig.json', 'tsconfig.build.json']);
+  assert.ok(categories.includes('configuration'));
+  assert.equal(hasCode, false);
+});
+
+test('classifyChangedFiles: dependency files', () => {
+  const { categories, hasCode } = classifyChangedFiles(['package.json', 'package-lock.json']);
+  assert.ok(categories.includes('dependency_update'));
+  assert.equal(hasCode, false);
+});
+
+test('classifyChangedFiles: test-only files', () => {
+  const { categories, hasCode } = classifyChangedFiles(['scripts/tests/pr_review.test.mjs']);
+  assert.ok(categories.includes('test_only'));
+  assert.equal(hasCode, false);
+});
+
+test('classifyChangedFiles: executable scripts set hasCode', () => {
+  const { categories, hasCode } = classifyChangedFiles(['scripts/lib/change_classifier.mjs']);
+  assert.equal(hasCode, true);
+});
+
+test('classifyChangedFiles: automation-scope md files are treated as code', () => {
+  // prompts/ is automation scope — not documentation
+  const { categories, hasCode } = classifyChangedFiles(['prompts/pr-review-system.md']);
+  assert.equal(hasCode, true);
+  assert.ok(!categories.includes('documentation'));
+});
+
+test('classifyChangedFiles: docs/code-generation.md is automation scope, not documentation', () => {
+  const { categories, hasCode } = classifyChangedFiles(['docs/code-generation.md']);
+  assert.equal(hasCode, true);
+  assert.ok(!categories.includes('documentation'));
+});
+
+test('classifyChangedFiles: mixed PR includes both code and docs categories', () => {
+  const { categories, hasCode } = classifyChangedFiles([
+    'scripts/lib/pr_review.mjs',
+    'docs/adr/0010-foo.md',
+  ]);
+  assert.equal(hasCode, true);
+  assert.ok(categories.includes('documentation'));
+});
+
+test('classifyChangedFiles: empty file list', () => {
+  const { categories, hasCode } = classifyChangedFiles([]);
+  assert.deepEqual(categories, []);
+  assert.equal(hasCode, false);
+});
+
+// ---------------------------------------------------------------------------
+// determineTestExpectation
+// ---------------------------------------------------------------------------
+
+test('determineTestExpectation: hasCode → tests_expected true', () => {
+  const { tests_expected } = determineTestExpectation(['documentation'], true);
+  assert.equal(tests_expected, true);
+});
+
+test('determineTestExpectation: documentation-only → tests_expected false', () => {
+  const { tests_expected, reason } = determineTestExpectation(['documentation'], false);
+  assert.equal(tests_expected, false);
+  assert.match(reason, /No executable behavior changed/);
+});
+
+test('determineTestExpectation: ci_cd-only → tests_expected false', () => {
+  const { tests_expected } = determineTestExpectation(['ci_cd'], false);
+  assert.equal(tests_expected, false);
+});
+
+test('determineTestExpectation: configuration-only → tests_expected false', () => {
+  const { tests_expected } = determineTestExpectation(['configuration'], false);
+  assert.equal(tests_expected, false);
+});
+
+test('determineTestExpectation: dependency_update-only → tests_expected false', () => {
+  const { tests_expected, reason } = determineTestExpectation(['dependency_update'], false);
+  assert.equal(tests_expected, false);
+  assert.match(reason, /Dependency version update/);
+});
+
+test('determineTestExpectation: test_only → tests_expected false', () => {
+  const { tests_expected, reason } = determineTestExpectation(['test_only'], false);
+  assert.equal(tests_expected, false);
+  assert.match(reason, /only test file changes/);
+});
+
+test('determineTestExpectation: mixed non-behavioral (docs + ci_cd) → tests_expected false', () => {
+  const { tests_expected } = determineTestExpectation(['documentation', 'ci_cd'], false);
+  assert.equal(tests_expected, false);
+});
+
+test('determineTestExpectation: empty categories → tests_expected true (undetermined)', () => {
+  const { tests_expected } = determineTestExpectation([], false);
+  assert.equal(tests_expected, true);
+});
+
+// ---------------------------------------------------------------------------
+// buildChangeClassificationContext
+// ---------------------------------------------------------------------------
+
+test('buildChangeClassificationContext: returns empty string for empty diff', () => {
+  assert.equal(buildChangeClassificationContext(''), '');
+});
+
+test('buildChangeClassificationContext: returns empty string when diff has no file markers', () => {
+  assert.equal(buildChangeClassificationContext('just text, no diff markers'), '');
+});
+
+test('buildChangeClassificationContext: doc-only diff produces tests_expected: false', () => {
+  const diff = [
+    'diff --git a/docs/adr/0010-foo.md b/docs/adr/0010-foo.md',
+    '+++ b/docs/adr/0010-foo.md',
+    '+Some ADR content',
+  ].join('\n');
+  const ctx = buildChangeClassificationContext(diff);
+  assert.match(ctx, /tests_expected: false/);
+  assert.match(ctx, /change_type: documentation/);
+  assert.match(ctx, /do not generate findings about missing tests/);
+});
+
+test('buildChangeClassificationContext: code change produces tests_expected: true', () => {
+  const diff = [
+    'diff --git a/scripts/lib/foo.mjs b/scripts/lib/foo.mjs',
+    '+++ b/scripts/lib/foo.mjs',
+    '+export function foo() {}',
+  ].join('\n');
+  const ctx = buildChangeClassificationContext(diff);
+  assert.match(ctx, /tests_expected: true/);
+  assert.match(ctx, /has_executable_code_changes: true/);
+});
+
+test('buildChangeClassificationContext: workflow-only diff produces tests_expected: false', () => {
+  const diff = [
+    'diff --git a/.github/workflows/pr-review.yml b/.github/workflows/pr-review.yml',
+    '+++ b/.github/workflows/pr-review.yml',
+    '+    - uses: actions/checkout@v4',
+  ].join('\n');
+  const ctx = buildChangeClassificationContext(diff);
+  assert.match(ctx, /tests_expected: false/);
+  assert.match(ctx, /change_type: ci_cd/);
+});
+
+test('buildChangeClassificationContext: mixed PR (code + docs) produces tests_expected: true', () => {
+  const diff = [
+    'diff --git a/scripts/lib/foo.mjs b/scripts/lib/foo.mjs',
+    '+++ b/scripts/lib/foo.mjs',
+    '+export function foo() {}',
+    'diff --git a/docs/runbook.md b/docs/runbook.md',
+    '+++ b/docs/runbook.md',
+    '+Some runbook update',
+  ].join('\n');
+  const ctx = buildChangeClassificationContext(diff);
+  assert.match(ctx, /tests_expected: true/);
+  assert.match(ctx, /change_type: mixed/);
+});
+
+test('buildChangeClassificationContext: dependency update produces tests_expected: false', () => {
+  const diff = [
+    'diff --git a/package.json b/package.json',
+    '+++ b/package.json',
+    '+  "some-dep": "^2.0.0"',
+  ].join('\n');
+  const ctx = buildChangeClassificationContext(diff);
+  assert.match(ctx, /tests_expected: false/);
+  assert.match(ctx, /dependency_update/);
+});
+
+test('buildChangeClassificationContext: prompts md file is treated as code', () => {
+  const diff = [
+    'diff --git a/prompts/pr-review-system.md b/prompts/pr-review-system.md',
+    '+++ b/prompts/pr-review-system.md',
+    '+New rule added',
+  ].join('\n');
+  const ctx = buildChangeClassificationContext(diff);
+  assert.match(ctx, /tests_expected: true/);
+  assert.match(ctx, /has_executable_code_changes: true/);
+});
+
+test('buildChangeClassificationContext: includes detected_categories in output', () => {
+  const diff = [
+    'diff --git a/config/labels.yaml b/config/labels.yaml',
+    '+++ b/config/labels.yaml',
+  ].join('\n');
+  const ctx = buildChangeClassificationContext(diff);
+  assert.match(ctx, /detected_categories: configuration/);
+});

--- a/scripts/tests/change_classifier.test.mjs
+++ b/scripts/tests/change_classifier.test.mjs
@@ -67,9 +67,16 @@ test('classifyChangedFiles: test-only files', () => {
   assert.equal(hasCode, false);
 });
 
-test('classifyChangedFiles: executable scripts set hasCode', () => {
-  const { categories, hasCode } = classifyChangedFiles(['scripts/lib/change_classifier.mjs']);
+test('classifyChangedFiles: executable scripts set hasCode and hasUncategorizedCode', () => {
+  const { hasCode, hasUncategorizedCode } = classifyChangedFiles(['scripts/lib/change_classifier.mjs']);
   assert.equal(hasCode, true);
+  assert.equal(hasUncategorizedCode, true);
+});
+
+test('classifyChangedFiles: workflow files set hasCode but not hasUncategorizedCode', () => {
+  const { hasCode, hasUncategorizedCode } = classifyChangedFiles(['.github/workflows/pr-review.yml']);
+  assert.equal(hasCode, true);
+  assert.equal(hasUncategorizedCode, false);
 });
 
 test('classifyChangedFiles: automation-scope md files are treated as code', () => {
@@ -191,6 +198,7 @@ test('buildChangeClassificationContext: workflow-only diff produces tests_expect
   const ctx = buildChangeClassificationContext(diff);
   assert.match(ctx, /tests_expected: true/);
   assert.match(ctx, /detected_categories: ci_cd/);
+  assert.match(ctx, /change_type: ci_cd/);
 });
 
 test('buildChangeClassificationContext: mixed PR (code + docs) produces tests_expected: true', () => {

--- a/scripts/tests/change_classifier.test.mjs
+++ b/scripts/tests/change_classifier.test.mjs
@@ -26,10 +26,10 @@ test('classifyChangedFiles: changelog and contributing are documentation', () =>
   assert.equal(hasCode, false);
 });
 
-test('classifyChangedFiles: CI/CD workflow files', () => {
+test('classifyChangedFiles: CI/CD workflow files in automation scope set hasCode', () => {
   const { categories, hasCode } = classifyChangedFiles(['.github/workflows/pr-review.yml']);
   assert.ok(categories.includes('ci_cd'));
-  assert.equal(hasCode, false);
+  assert.equal(hasCode, true);
 });
 
 test('classifyChangedFiles: configuration files', () => {
@@ -44,10 +44,21 @@ test('classifyChangedFiles: tsconfig is configuration', () => {
   assert.equal(hasCode, false);
 });
 
-test('classifyChangedFiles: dependency files', () => {
-  const { categories, hasCode } = classifyChangedFiles(['package.json', 'package-lock.json']);
+test('classifyChangedFiles: lock files are dependency_update', () => {
+  const { categories, hasCode } = classifyChangedFiles(['package-lock.json', 'yarn.lock']);
   assert.ok(categories.includes('dependency_update'));
   assert.equal(hasCode, false);
+});
+
+test('classifyChangedFiles: package.json alone is treated as executable code', () => {
+  const { hasCode } = classifyChangedFiles(['package.json']);
+  assert.equal(hasCode, true);
+});
+
+test('classifyChangedFiles: workflow files are ci_cd with hasCode true (automation scope)', () => {
+  const { categories, hasCode } = classifyChangedFiles(['.github/workflows/pr-review.yml']);
+  assert.ok(categories.includes('ci_cd'));
+  assert.equal(hasCode, true);
 });
 
 test('classifyChangedFiles: test-only files', () => {
@@ -171,15 +182,15 @@ test('buildChangeClassificationContext: code change produces tests_expected: tru
   assert.match(ctx, /has_executable_code_changes: true/);
 });
 
-test('buildChangeClassificationContext: workflow-only diff produces tests_expected: false', () => {
+test('buildChangeClassificationContext: workflow-only diff produces tests_expected: true (automation scope)', () => {
   const diff = [
     'diff --git a/.github/workflows/pr-review.yml b/.github/workflows/pr-review.yml',
     '+++ b/.github/workflows/pr-review.yml',
     '+    - uses: actions/checkout@v4',
   ].join('\n');
   const ctx = buildChangeClassificationContext(diff);
-  assert.match(ctx, /tests_expected: false/);
-  assert.match(ctx, /change_type: ci_cd/);
+  assert.match(ctx, /tests_expected: true/);
+  assert.match(ctx, /detected_categories: ci_cd/);
 });
 
 test('buildChangeClassificationContext: mixed PR (code + docs) produces tests_expected: true', () => {
@@ -196,15 +207,26 @@ test('buildChangeClassificationContext: mixed PR (code + docs) produces tests_ex
   assert.match(ctx, /change_type: mixed/);
 });
 
-test('buildChangeClassificationContext: dependency update produces tests_expected: false', () => {
+test('buildChangeClassificationContext: lock-file-only diff produces tests_expected: false', () => {
   const diff = [
-    'diff --git a/package.json b/package.json',
-    '+++ b/package.json',
+    'diff --git a/package-lock.json b/package-lock.json',
+    '+++ b/package-lock.json',
     '+  "some-dep": "^2.0.0"',
   ].join('\n');
   const ctx = buildChangeClassificationContext(diff);
   assert.match(ctx, /tests_expected: false/);
   assert.match(ctx, /dependency_update/);
+});
+
+test('buildChangeClassificationContext: package.json alone produces tests_expected: true', () => {
+  const diff = [
+    'diff --git a/package.json b/package.json',
+    '+++ b/package.json',
+    '+  "type": "commonjs"',
+  ].join('\n');
+  const ctx = buildChangeClassificationContext(diff);
+  assert.match(ctx, /tests_expected: true/);
+  assert.match(ctx, /has_executable_code_changes: true/);
 });
 
 test('buildChangeClassificationContext: prompts md file is treated as code', () => {


### PR DESCRIPTION
Introduces an explicit classification phase before generating review
findings so that documentation-only, CI/CD-only, configuration-only,
and dependency-update PRs no longer receive irrelevant test-coverage
complaints.

New flow:
  PR → Change Classification → Review Criteria Selection → Findings

Changes:
- scripts/lib/change_classifier.mjs: new module that inspects changed
  file paths (reusing extractChangedFiles from coverage_checker) and
  produces a structured context block with change_type,
  detected_categories, has_executable_code_changes, tests_expected, and
  tests_expected_reason.  Automation-scope .md files (prompts/,
  docs/code-generation.md) are correctly treated as behavioural rather
  than documentation.
- scripts/tests/change_classifier.test.mjs: 29 unit tests covering
  classifyChangedFiles, determineTestExpectation, and
  buildChangeClassificationContext across all change types and edge
  cases.
- prompts/pr-review-system.md: added "Context-aware review" rule block
  instructing the LLM to read the classification context, honour
  tests_expected, and apply criteria appropriate to the detected type
  (documentation, ci_cd, configuration, dependency_update, test_only,
  feature/bugfix/refactor/security, mixed).
- prompts/pr-review-user.md: added "Change Classification" section to
  the review output template; raised word limit to 250 to accommodate
  the new section; added explicit constraint to omit test-coverage
  findings when tests_expected is false.
- scripts/pr_review.mjs: import buildChangeClassificationContext and
  append it to the user prompt alongside the existing automation gate
  context.

https://claude.ai/code/session_01Kv5EHWB7ZhzjeP8NK3j7rp